### PR TITLE
test: sidecar deserialization version-compatibility tests

### DIFF
--- a/tests/PhotoOrganizer.Infrastructure.Tests/SidecarReaderTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/SidecarReaderTests.cs
@@ -135,4 +135,122 @@ public sealed class SidecarReaderTests
         }
         catch (SidecarParsingException) { }
     }
+
+    [TestMethod]
+    public async Task ReadPhotoMeta_PreviousVersion_MissingFields_UsesDefaults()
+    {
+        var photoPath = Path.Combine(_tempDir.FullName, "test.jpg");
+        var sidecarPath = Path.Combine(_tempDir.FullName, "test.meta.json");
+        var capturedAt = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        await File.WriteAllTextAsync(sidecarPath, $$"""
+            {
+              "capturedAt": "{{capturedAt:O}}"
+            }
+            """);
+
+        var result = await _reader.ReadPhotoMetaAsync(photoPath);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result.Version);
+        Assert.AreEqual(capturedAt, result.CapturedAt);
+        Assert.IsNull(result.DuplicateGroupId);
+        Assert.IsFalse(result.IsPreferred);
+        Assert.AreEqual(0, result.Tags.Count);
+        Assert.AreEqual(0, result.CrawlSteps.Count);
+    }
+
+    [TestMethod]
+    public async Task ReadPhotoMeta_WithCrawlSteps_DeserializesSteps()
+    {
+        var photoPath = Path.Combine(_tempDir.FullName, "test.jpg");
+        var sidecarPath = Path.Combine(_tempDir.FullName, "test.meta.json");
+        var metadataCompletedAt = new DateTimeOffset(2024, 3, 10, 12, 0, 0, TimeSpan.Zero);
+        var duplicatesCompletedAt = new DateTimeOffset(2024, 3, 10, 12, 5, 0, TimeSpan.Zero);
+
+        await File.WriteAllTextAsync(sidecarPath, $$"""
+            {
+              "version": 1,
+              "crawlSteps": {
+                "metadata": { "version": 1, "completedAt": "{{metadataCompletedAt:O}}" },
+                "duplicates": { "version": 1, "completedAt": "{{duplicatesCompletedAt:O}}" }
+              }
+            }
+            """);
+
+        var result = await _reader.ReadPhotoMetaAsync(photoPath);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.CrawlSteps.Count);
+        Assert.IsTrue(result.CrawlSteps.ContainsKey("metadata"));
+        Assert.AreEqual(1, result.CrawlSteps["metadata"].Version);
+        Assert.AreEqual(metadataCompletedAt, result.CrawlSteps["metadata"].CompletedAt);
+        Assert.IsTrue(result.CrawlSteps.ContainsKey("duplicates"));
+        Assert.AreEqual(duplicatesCompletedAt, result.CrawlSteps["duplicates"].CompletedAt);
+    }
+
+    [TestMethod]
+    public async Task ReadPhotoMeta_FutureVersion_UnknownFields_DoesNotThrow()
+    {
+        var photoPath = Path.Combine(_tempDir.FullName, "test.jpg");
+        var sidecarPath = Path.Combine(_tempDir.FullName, "test.meta.json");
+
+        await File.WriteAllTextAsync(sidecarPath, """
+            {
+              "version": 99,
+              "capturedAt": null,
+              "unknownTopLevelField": "some value",
+              "crawlSteps": {
+                "metadata": { "version": 1, "completedAt": "2024-01-01T00:00:00Z", "unknownStepField": true }
+              },
+              "anotherFutureField": { "nested": 42 }
+            }
+            """);
+
+        var result = await _reader.ReadPhotoMetaAsync(photoPath);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(99, result.Version);
+        Assert.AreEqual(1, result.CrawlSteps.Count);
+    }
+
+    [TestMethod]
+    public async Task ReadFolderSidecar_PreviousVersion_MissingFields_UsesDefaults()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_tempDir.FullName, "_folder.json"), """
+            {
+              "label": "Vacation",
+              "enabled": false
+            }
+            """);
+
+        var result = await _reader.ReadFolderSidecarAsync(_tempDir.FullName);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result.Version);
+        Assert.AreEqual("Vacation", result.Label);
+        Assert.AreEqual("mixed", result.Type);
+        Assert.IsFalse(result.Enabled);
+    }
+
+    [TestMethod]
+    public async Task ReadFolderSidecar_FutureVersion_UnknownFields_DoesNotThrow()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_tempDir.FullName, "_folder.json"), """
+            {
+              "version": 99,
+              "label": "Future Folder",
+              "type": "originals",
+              "enabled": true,
+              "unknownField": "something new",
+              "anotherFuture": { "x": 1 }
+            }
+            """);
+
+        var result = await _reader.ReadFolderSidecarAsync(_tempDir.FullName);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(99, result.Version);
+        Assert.AreEqual("Future Folder", result.Label);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 5 unit tests to  covering the three-scenario compatibility matrix (previous version / current v1 / future version) for both  and 
- Confirms the existing production code already handles all scenarios correctly
- No production code changes

## Test plan

- [ ]   Determining projects to restore...
  All projects are up-to-date for restore.
  PhotoOrganizer.Domain -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Domain/bin/Debug/net10.0/PhotoOrganizer.Domain.dll
  PhotoOrganizer.Crawler -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Crawler/bin/Debug/net10.0/PhotoOrganizer.Crawler.dll
  PhotoOrganizer.Application -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Application/bin/Debug/net10.0/PhotoOrganizer.Application.dll
  PhotoOrganizer.Infrastructure -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Infrastructure/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.dll
  PhotoOrganizer.Crawler.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Crawler.Tests/bin/Debug/net10.0/PhotoOrganizer.Crawler.Tests.dll
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Crawler.Tests/bin/Debug/net10.0/PhotoOrganizer.Crawler.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.
  PhotoOrganizer.Application.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Application.Tests/bin/Debug/net10.0/PhotoOrganizer.Application.Tests.dll
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Application.Tests/bin/Debug/net10.0/PhotoOrganizer.Application.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 9 ms - PhotoOrganizer.Application.Tests.dll (net10.0)

Passed!  - Failed:     0, Passed:    63, Skipped:     0, Total:    63, Duration: 191 ms - PhotoOrganizer.Crawler.Tests.dll (net10.0)
  PhotoOrganizer.Infrastructure.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Infrastructure.Tests/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.Tests.dll
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Infrastructure.Tests/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.Tests.dll (.NETCoreApp,Version=v10.0)
  PhotoOrganizer.Server -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Server/bin/Debug/net10.0/PhotoOrganizer.Server.dll
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    37, Skipped:     0, Total:    37, Duration: 163 ms - PhotoOrganizer.Infrastructure.Tests.dll (net10.0)
  PhotoOrganizer.Server.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Server.Tests/bin/Debug/net10.0/PhotoOrganizer.Server.Tests.dll
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Server.Tests/bin/Debug/net10.0/PhotoOrganizer.Server.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 403 ms - PhotoOrganizer.Server.Tests.dll (net10.0) — all 104 tests pass

Closes #13