### PR TITLE
fix: set vite dev server port to 6173

### DIFF
--- a/src/PhotoOrganizer.Web/vite.config.ts
+++ b/src/PhotoOrganizer.Web/vite.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    port: 6173,
+    strictPort: true,
     proxy: {
       '/api': {
         target: 'http://localhost:6192',


### PR DESCRIPTION
Vite defaults to port 5173, but the entire project expects port 6173 (docs, CLAUDE.md, and the CORS allowlist in Program.cs). This adds  and  to the  block in vite.config.ts so the dev server always binds to the correct port. Closes #27