### PR TITLE
chore: upgrade server-side .NET dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,21 +2,21 @@
   <ItemGroup>
     <!-- Crawler -->
     <PackageVersion Include="System.CommandLine" Version="3.0.0-preview.2.26159.112" />
-    <PackageVersion Include="MetadataExtractor" Version="2.9.2" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
+    <PackageVersion Include="MetadataExtractor" Version="2.9.3" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <!-- Web API -->
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
     <!-- Tools -->
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <!-- Testing -->
-    <PackageVersion Include="MSTest" Version="4.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageVersion Include="MSTest" Version="4.2.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.300",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary

- Bump all .NET 10 packages to the 10.0.8 servicing line (Sqlite, Extensions.*, AspNetCore.OpenApi, Mvc.Testing)
- MetadataExtractor 2.9.2 → 2.9.3
- Swashbuckle.AspNetCore 10.1.4 → 10.2.1
- MSTest 4.1.0 → 4.2.3
- Pin SDK to the 10.0.300 band in global.json

**SixLabors.ImageSharp held at 3.1.12** — version 4.0 introduced build-time license enforcement requiring enrollment at licensing.sixlabors.com even for qualifying open-source projects. Can be addressed separately once enrolled.

All changes are in Directory.Packages.props (centralized versions) — no individual .csproj edits required. Vulnerability scan is clean.

## Test plan

- [x] dotnet build — clean (TreatWarningsAsErrors on)
- [x] Unit tests (104 tests across all projects) — all pass
- [x] Integration / end-to-end tests — all pass
- [x] dotnet list package --vulnerable — clean

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)