### PR TITLE
feat(slideshow): keyboard shortcuts, overlay feedback, adjustable display time

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Photos live across multiple folders on a Windows PC and a Synology NAS. This app
 ## Key Features
 
 - Browse photos across multiple configured source folders
-- Slideshow mode with smooth transitions
+- Slideshow mode with smooth transitions and Ken Burns effects; fully keyboard-navigable
 - Originals and edited versions tracked separately; edited versions preferred for display
 - Duplicate detection based on file names across folders
 - Metadata stored as sidecar files alongside photos — no database lock-in
@@ -81,6 +81,19 @@ dotnet run --project src/PhotoOrganizer.Crawler -- run --mode full
 ```
 
 Open [http://localhost:6192](http://localhost:6192) in your browser.
+
+### Slideshow keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| `←` / `→` | Previous / Next photo |
+| `Space` | Play / Pause |
+| `+` / `-` | Increase / Decrease display time (10s steps below 60s, 60s steps above) |
+| `I` | Show photo info |
+| `?` | Show this shortcut reference |
+| `Esc` | Exit slideshow |
+
+The display time defaults to **30 seconds** and can be adjusted between 10 seconds and 10 minutes. The Ken Burns effect duration follows the display time automatically. To change the default, set `PhotoOrganizer:Slideshow:IntervalSeconds` in `appsettings.json`.
 
 ### Frontend dev mode
 

--- a/src/PhotoOrganizer.Server/appsettings.example.json
+++ b/src/PhotoOrganizer.Server/appsettings.example.json
@@ -5,7 +5,7 @@
       "\\\\NAS\\Photos"
     ],
     "Slideshow": {
-      "IntervalSeconds": 8,
+      "IntervalSeconds": 30,
       "TransitionMs": 500
     }
   },

--- a/src/PhotoOrganizer.Web/src/App.css
+++ b/src/PhotoOrganizer.Web/src/App.css
@@ -391,3 +391,95 @@
 .slideshow-exit-btn:hover {
   border-color: #fff;
 }
+
+/* Feedback / info overlay — centred, auto-dismissed by useOverlayMessage */
+.slideshow-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: min(560px, 90vw);
+  width: max-content;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(8px);
+  border-radius: 12px;
+  padding: 20px 28px;
+  color: #fff;
+  font-size: 15px;
+  line-height: 1.5;
+  pointer-events: none;
+  animation: slideshow-overlay-in 0.2s ease;
+  z-index: 10;
+}
+
+@keyframes slideshow-overlay-in {
+  from { opacity: 0; transform: translate(-50%, -48%); }
+  to   { opacity: 1; transform: translate(-50%, -50%); }
+}
+
+/* Photo info panel inside the overlay */
+.slideshow-info-panel {
+  min-width: 260px;
+}
+
+.slideshow-info-dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 16px;
+  margin: 0;
+}
+
+.slideshow-info-dl dt {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.slideshow-info-dl dd {
+  color: #fff;
+  font-size: 13px;
+  margin: 0;
+  word-break: break-all;
+}
+
+.slideshow-info-path {
+  font-size: 11px;
+  opacity: 0.75;
+}
+
+/* Shortcut help panel inside the overlay */
+.slideshow-shortcut-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.slideshow-shortcut-table {
+  border-collapse: collapse;
+  font-size: 13px;
+  min-width: 260px;
+}
+
+.slideshow-shortcut-table td {
+  padding: 4px 0;
+  vertical-align: top;
+}
+
+.slideshow-shortcut-table td:first-child {
+  padding-right: 20px;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.slideshow-shortcut-table kbd {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-family: var(--mono, monospace);
+  font-size: 12px;
+}

--- a/src/PhotoOrganizer.Web/src/components/PhotoInfoPanel.tsx
+++ b/src/PhotoOrganizer.Web/src/components/PhotoInfoPanel.tsx
@@ -1,0 +1,51 @@
+import type { PhotoDto } from '../api/types';
+
+interface PhotoInfoPanelProps {
+  photo: PhotoDto;
+  intervalSeconds: number;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return value;
+  }
+}
+
+export function PhotoInfoPanel({ photo, intervalSeconds }: PhotoInfoPanelProps) {
+  return (
+    <div className="slideshow-info-panel">
+      <dl className="slideshow-info-dl">
+        <dt>File</dt>
+        <dd>{photo.fileName}</dd>
+
+        <dt>Captured</dt>
+        <dd>{formatDate(photo.capturedAt)}</dd>
+
+        <dt>Folder type</dt>
+        <dd>{photo.folderType}</dd>
+
+        {photo.tags.length > 0 && (
+          <>
+            <dt>Tags</dt>
+            <dd>{photo.tags.join(', ')}</dd>
+          </>
+        )}
+
+        <dt>Path</dt>
+        <dd className="slideshow-info-path">{photo.filePath}</dd>
+
+        <dt>Display time</dt>
+        <dd>{intervalSeconds}s</dd>
+      </dl>
+    </div>
+  );
+}

--- a/src/PhotoOrganizer.Web/src/components/ShortcutHelp.tsx
+++ b/src/PhotoOrganizer.Web/src/components/ShortcutHelp.tsx
@@ -1,0 +1,17 @@
+export function ShortcutHelp() {
+  return (
+    <div className="slideshow-shortcut-help">
+      <h3 className="slideshow-shortcut-title">Keyboard shortcuts</h3>
+      <table className="slideshow-shortcut-table">
+        <tbody>
+          <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Previous / Next photo</td></tr>
+          <tr><td><kbd>Space</kbd></td><td>Play / Pause</td></tr>
+          <tr><td><kbd>+</kbd> / <kbd>−</kbd></td><td>Increase / Decrease display time</td></tr>
+          <tr><td><kbd>I</kbd></td><td>Show photo info</td></tr>
+          <tr><td><kbd>?</kbd></td><td>Show this help</td></tr>
+          <tr><td><kbd>Esc</kbd></td><td>Exit slideshow</td></tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/PhotoOrganizer.Web/src/hooks/useKeyboardNavigation.ts
+++ b/src/PhotoOrganizer.Web/src/hooks/useKeyboardNavigation.ts
@@ -4,6 +4,10 @@ export interface KeyboardNavigationConfig {
   onNext?: () => void;
   onPrevious?: () => void;
   onTogglePause?: () => void;
+  onIncreaseDuration?: () => void;
+  onDecreaseDuration?: () => void;
+  onShowInfo?: () => void;
+  onShowHelp?: () => void;
   onExit?: () => void;
   enabled?: boolean;
 }
@@ -12,6 +16,10 @@ export function useKeyboardNavigation({
   onNext,
   onPrevious,
   onTogglePause,
+  onIncreaseDuration,
+  onDecreaseDuration,
+  onShowInfo,
+  onShowHelp,
   onExit,
   enabled = true,
 }: KeyboardNavigationConfig): void {
@@ -27,7 +35,6 @@ export function useKeyboardNavigation({
     }
 
     switch (event.key) {
-      case ' ':
       case 'ArrowRight':
         event.preventDefault();
         onNext?.();
@@ -36,17 +43,38 @@ export function useKeyboardNavigation({
         event.preventDefault();
         onPrevious?.();
         break;
+      case ' ':
       case 'p':
       case 'P':
         event.preventDefault();
         onTogglePause?.();
+        break;
+      case '+':
+      case '=':
+        event.preventDefault();
+        onIncreaseDuration?.();
+        break;
+      case '-':
+      case '_':
+        event.preventDefault();
+        onDecreaseDuration?.();
+        break;
+      case 'i':
+      case 'I':
+        event.preventDefault();
+        onShowInfo?.();
+        break;
+      case '?':
+      case '/':
+        event.preventDefault();
+        onShowHelp?.();
         break;
       case 'Escape':
         event.preventDefault();
         onExit?.();
         break;
     }
-  }, [enabled, onNext, onPrevious, onTogglePause, onExit]);
+  }, [enabled, onNext, onPrevious, onTogglePause, onIncreaseDuration, onDecreaseDuration, onShowInfo, onShowHelp, onExit]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/src/PhotoOrganizer.Web/src/hooks/useOverlayMessage.ts
+++ b/src/PhotoOrganizer.Web/src/hooks/useOverlayMessage.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+
+const DEFAULT_DURATION_MS = 3_000;
+
+export interface OverlayMessageState {
+  message: ReactNode | null;
+  showMessage: (content: ReactNode, durationMs?: number) => void;
+}
+
+/**
+ * Manages a transient on-screen overlay message that fades out automatically.
+ * Suitable for keyboard-shortcut feedback and action confirmations.
+ */
+export function useOverlayMessage(): OverlayMessageState {
+  const [message, setMessage] = useState<ReactNode | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const showMessage = useCallback((content: ReactNode, durationMs = DEFAULT_DURATION_MS) => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    setMessage(content);
+    timerRef.current = window.setTimeout(() => {
+      setMessage(null);
+      timerRef.current = null;
+    }, durationMs);
+  }, []);
+
+  // Clear timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return { message, showMessage };
+}

--- a/src/PhotoOrganizer.Web/src/pages/SlideshowPage.tsx
+++ b/src/PhotoOrganizer.Web/src/pages/SlideshowPage.tsx
@@ -4,13 +4,18 @@ import { getConfig } from '../api/client';
 import type { SlideshowConfigDto } from '../api/types';
 import { useSlideshow } from '../hooks/useSlideshow';
 import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
+import { useOverlayMessage } from '../hooks/useOverlayMessage';
 import { SlideshowImage } from '../components/SlideshowImage';
+import { PhotoInfoPanel } from '../components/PhotoInfoPanel';
+import { ShortcutHelp } from '../components/ShortcutHelp';
 import { generateKenBurnsConfig } from '../utils/kenBurns';
+import { nextDuration, formatDuration } from '../utils/duration';
 import type { KenBurnsConfig } from '../utils/kenBurns';
 import type { PhotoDto } from '../api/types';
 
-const DEFAULT_CONFIG: SlideshowConfigDto = { intervalSeconds: 8, transitionMs: 500 };
+const DEFAULT_CONFIG: SlideshowConfigDto = { intervalSeconds: 30, transitionMs: 500 };
 const CONTROLS_HIDE_DELAY_MS = 3_000;
+const INFO_DURATION_MS = 10_000;
 
 interface DisplayState {
   photo: PhotoDto;
@@ -22,14 +27,21 @@ export default function SlideshowPage() {
   const navigate = useNavigate();
   const [config, setConfig] = useState<SlideshowConfigDto>(DEFAULT_CONFIG);
 
+  // intervalSeconds is mutable at runtime via + / - keys.
+  // intervalMs is derived from it and drives both the slideshow timer and Ken Burns duration.
+  // Declared before the config effect so setIntervalSeconds is in scope there.
+  const [intervalSeconds, setIntervalSeconds] = useState<number>(DEFAULT_CONFIG.intervalSeconds);
+
   // Load config once on mount; fall back to defaults on error
   useEffect(() => {
     getConfig()
-      .then(c => setConfig(c.slideshow))
+      .then(c => {
+        setConfig(c.slideshow);
+        setIntervalSeconds(c.slideshow.intervalSeconds);
+      })
       .catch(() => { /* use defaults */ });
   }, []);
-
-  const intervalMs = config.intervalSeconds * 1000;
+  const intervalMs = intervalSeconds * 1000;
   const transitionMs = config.transitionMs;
 
   const slideshow = useSlideshow({ intervalMs });
@@ -78,12 +90,53 @@ export default function SlideshowPage() {
     };
   }, []);
 
+  // Feedback overlay — shown briefly on keyboard actions (and for 10s on info / help)
+  const overlay = useOverlayMessage();
+
   const handleExit = useCallback(() => navigate('/'), [navigate]);
+
+  // Pause/resume — also shows an overlay
+  const handleTogglePause = useCallback(() => {
+    slideshow.togglePause();
+    // After toggling, paused will flip — show what the new state will be
+    overlay.showMessage(slideshow.paused ? 'Playing' : 'Paused');
+  }, [slideshow, overlay]);
+
+  // Duration adjustment
+  const handleIncreaseDuration = useCallback(() => {
+    const next = nextDuration(intervalSeconds, 1);
+    setIntervalSeconds(next);
+    overlay.showMessage(`Display time: ${formatDuration(next)}`);
+  }, [intervalSeconds, overlay]);
+
+  const handleDecreaseDuration = useCallback(() => {
+    const next = nextDuration(intervalSeconds, -1);
+    setIntervalSeconds(next);
+    overlay.showMessage(`Display time: ${formatDuration(next)}`);
+  }, [intervalSeconds, overlay]);
+
+  // Info panel
+  const handleShowInfo = useCallback(() => {
+    if (!currentDisplay) return;
+    overlay.showMessage(
+      <PhotoInfoPanel photo={currentDisplay.photo} intervalSeconds={intervalSeconds} />,
+      INFO_DURATION_MS,
+    );
+  }, [currentDisplay, intervalSeconds, overlay]);
+
+  // Shortcut help
+  const handleShowHelp = useCallback(() => {
+    overlay.showMessage(<ShortcutHelp />, INFO_DURATION_MS);
+  }, [overlay]);
 
   useKeyboardNavigation({
     onNext: slideshow.next,
     onPrevious: slideshow.previous,
-    onTogglePause: slideshow.togglePause,
+    onTogglePause: handleTogglePause,
+    onIncreaseDuration: handleIncreaseDuration,
+    onDecreaseDuration: handleDecreaseDuration,
+    onShowInfo: handleShowInfo,
+    onShowHelp: handleShowHelp,
     onExit: handleExit,
   });
 
@@ -125,14 +178,21 @@ export default function SlideshowPage() {
         <div className="slideshow-error-indicator" title="Network error — retrying">⚠</div>
       )}
 
+      {/* Feedback / info overlay */}
+      {overlay.message && (
+        <div className="slideshow-overlay">
+          {overlay.message}
+        </div>
+      )}
+
       {/* Controls overlay */}
       <div className={`slideshow-controls${controlsVisible ? ' visible' : ''}`}>
         <div className="slideshow-controls-inner">
           <button className="slideshow-control-btn" onClick={slideshow.previous} title="Previous (←)">‹</button>
-          <button className="slideshow-control-btn" onClick={slideshow.togglePause} title={slideshow.paused ? 'Resume (P)' : 'Pause (P)'}>
+          <button className="slideshow-control-btn" onClick={handleTogglePause} title={slideshow.paused ? 'Resume (Space)' : 'Pause (Space)'}>
             {slideshow.paused ? '▶' : '⏸'}
           </button>
-          <button className="slideshow-control-btn" onClick={slideshow.next} title="Next (→ or Space)">›</button>
+          <button className="slideshow-control-btn" onClick={slideshow.next} title="Next (→)">›</button>
           <button className="slideshow-control-btn slideshow-exit-ctrl" onClick={handleExit} title="Exit (Esc)">✕</button>
         </div>
       </div>

--- a/src/PhotoOrganizer.Web/src/test/duration.test.ts
+++ b/src/PhotoOrganizer.Web/src/test/duration.test.ts
@@ -1,0 +1,76 @@
+import { nextDuration, formatDuration, MIN_INTERVAL_SECONDS, MAX_INTERVAL_SECONDS } from '../utils/duration';
+
+describe('nextDuration', () => {
+  // ── Increasing ──
+
+  it('steps by +10s below 60s', () => {
+    expect(nextDuration(10, 1)).toBe(20);
+    expect(nextDuration(20, 1)).toBe(30);
+    expect(nextDuration(50, 1)).toBe(60);
+  });
+
+  it('crosses the 60s boundary with a +10s step from 50s', () => {
+    expect(nextDuration(50, 1)).toBe(60);
+  });
+
+  it('steps by +60s at 60s', () => {
+    expect(nextDuration(60, 1)).toBe(120);
+  });
+
+  it('steps by +60s above 60s', () => {
+    expect(nextDuration(120, 1)).toBe(180);
+    expect(nextDuration(300, 1)).toBe(360);
+  });
+
+  it('clamps at MAX_INTERVAL_SECONDS when increasing', () => {
+    expect(nextDuration(MAX_INTERVAL_SECONDS, 1)).toBe(MAX_INTERVAL_SECONDS);
+    expect(nextDuration(MAX_INTERVAL_SECONDS - 10, 1)).toBe(MAX_INTERVAL_SECONDS);
+  });
+
+  // ── Decreasing ──
+
+  it('steps by -10s below 120s', () => {
+    expect(nextDuration(30, -1)).toBe(20);
+    expect(nextDuration(60, -1)).toBe(50);
+    expect(nextDuration(110, -1)).toBe(100);
+  });
+
+  it('crosses the 120s boundary with a -60s step from 120s', () => {
+    expect(nextDuration(120, -1)).toBe(60);
+  });
+
+  it('steps by -60s above 120s', () => {
+    expect(nextDuration(180, -1)).toBe(120);
+    expect(nextDuration(360, -1)).toBe(300);
+  });
+
+  it('clamps at MIN_INTERVAL_SECONDS when decreasing', () => {
+    expect(nextDuration(MIN_INTERVAL_SECONDS, -1)).toBe(MIN_INTERVAL_SECONDS);
+    expect(nextDuration(MIN_INTERVAL_SECONDS + 5, -1)).toBe(MIN_INTERVAL_SECONDS);
+  });
+
+  // ── Symmetry around the 60/120 boundary ──
+
+  it('60 +60 → 120', () => expect(nextDuration(60, 1)).toBe(120));
+  it('120 -60 → 60', () => expect(nextDuration(120, -1)).toBe(60));
+  it('60 -10 → 50', () => expect(nextDuration(60, -1)).toBe(50));
+});
+
+describe('formatDuration', () => {
+  it('formats seconds under a minute', () => {
+    expect(formatDuration(10)).toBe('10s');
+    expect(formatDuration(30)).toBe('30s');
+    expect(formatDuration(59)).toBe('59s');
+  });
+
+  it('formats exact minutes', () => {
+    expect(formatDuration(60)).toBe('1m');
+    expect(formatDuration(120)).toBe('2m');
+    expect(formatDuration(600)).toBe('10m');
+  });
+
+  it('formats minutes and seconds', () => {
+    expect(formatDuration(90)).toBe('1m 30s');
+    expect(formatDuration(150)).toBe('2m 30s');
+  });
+});

--- a/src/PhotoOrganizer.Web/src/test/useKeyboardNavigation.test.ts
+++ b/src/PhotoOrganizer.Web/src/test/useKeyboardNavigation.test.ts
@@ -1,0 +1,123 @@
+import { renderHook } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
+import type { KeyboardNavigationConfig } from '../hooks/useKeyboardNavigation';
+
+function press(key: string, target: Element | Window = window) {
+  fireEvent.keyDown(target, { key });
+}
+
+function renderNav(config: KeyboardNavigationConfig) {
+  return renderHook(() => useKeyboardNavigation(config));
+}
+
+describe('useKeyboardNavigation', () => {
+  it('ArrowRight calls onNext', () => {
+    const onNext = vi.fn();
+    renderNav({ onNext });
+    press('ArrowRight');
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('ArrowLeft calls onPrevious', () => {
+    const onPrevious = vi.fn();
+    renderNav({ onPrevious });
+    press('ArrowLeft');
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('Space calls onTogglePause (not onNext)', () => {
+    const onNext = vi.fn();
+    const onTogglePause = vi.fn();
+    renderNav({ onNext, onTogglePause });
+    press(' ');
+    expect(onTogglePause).toHaveBeenCalledTimes(1);
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it('p and P call onTogglePause', () => {
+    const onTogglePause = vi.fn();
+    renderNav({ onTogglePause });
+    press('p');
+    press('P');
+    expect(onTogglePause).toHaveBeenCalledTimes(2);
+  });
+
+  it('+ and = call onIncreaseDuration', () => {
+    const onIncreaseDuration = vi.fn();
+    renderNav({ onIncreaseDuration });
+    press('+');
+    press('=');
+    expect(onIncreaseDuration).toHaveBeenCalledTimes(2);
+  });
+
+  it('- and _ call onDecreaseDuration', () => {
+    const onDecreaseDuration = vi.fn();
+    renderNav({ onDecreaseDuration });
+    press('-');
+    press('_');
+    expect(onDecreaseDuration).toHaveBeenCalledTimes(2);
+  });
+
+  it('i and I call onShowInfo', () => {
+    const onShowInfo = vi.fn();
+    renderNav({ onShowInfo });
+    press('i');
+    press('I');
+    expect(onShowInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('? and / call onShowHelp', () => {
+    const onShowHelp = vi.fn();
+    renderNav({ onShowHelp });
+    press('?');
+    press('/');
+    expect(onShowHelp).toHaveBeenCalledTimes(2);
+  });
+
+  it('Escape calls onExit', () => {
+    const onExit = vi.fn();
+    renderNav({ onExit });
+    press('Escape');
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores all keys when disabled', () => {
+    const callbacks = {
+      onNext: vi.fn(),
+      onPrevious: vi.fn(),
+      onTogglePause: vi.fn(),
+      onIncreaseDuration: vi.fn(),
+      onDecreaseDuration: vi.fn(),
+      onShowInfo: vi.fn(),
+      onShowHelp: vi.fn(),
+      onExit: vi.fn(),
+      enabled: false,
+    };
+    renderNav(callbacks);
+    ['ArrowRight', 'ArrowLeft', ' ', '+', '-', 'i', '?', 'Escape'].forEach(k => press(k));
+    Object.values(callbacks).forEach(v => {
+      if (typeof v === 'function') expect(v).not.toHaveBeenCalled();
+    });
+  });
+
+  it('ignores events from input elements', () => {
+    const onNext = vi.fn();
+    renderNav({ onNext });
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    press('ArrowRight', input);
+    expect(onNext).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it('ignores events from textarea elements', () => {
+    const onTogglePause = vi.fn();
+    renderNav({ onTogglePause });
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    press(' ', textarea);
+    expect(onTogglePause).not.toHaveBeenCalled();
+    document.body.removeChild(textarea);
+  });
+});

--- a/src/PhotoOrganizer.Web/src/utils/duration.ts
+++ b/src/PhotoOrganizer.Web/src/utils/duration.ts
@@ -1,0 +1,29 @@
+/**
+ * Minimum and maximum display time per photo (seconds).
+ */
+export const MIN_INTERVAL_SECONDS = 10;
+export const MAX_INTERVAL_SECONDS = 600; // 10 minutes
+
+/**
+ * Compute the next display-time value in the stepped sequence:
+ *   - Increasing: +10s while current < 60s; +60s at 60s or above.
+ *   - Decreasing: -10s while current < 120s; -60s at 120s or above.
+ * Result is clamped to [MIN_INTERVAL_SECONDS, MAX_INTERVAL_SECONDS].
+ */
+export function nextDuration(current: number, direction: 1 | -1): number {
+  const step = direction > 0
+    ? (current >= 60 ? 60 : 10)
+    : (current >= 120 ? 60 : 10);
+  return Math.max(MIN_INTERVAL_SECONDS, Math.min(MAX_INTERVAL_SECONDS, current + direction * step));
+}
+
+/**
+ * Format a duration in seconds to a human-readable string.
+ * Under a minute: "30s". At or over a minute: "2m", "1m 30s".
+ */
+export function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return s === 0 ? `${m}m` : `${m}m ${s}s`;
+}


### PR DESCRIPTION
## Summary

- **Rebind Space → play/pause** (was next; Arrow keys remain prev/next)
- **+/− keys** adjust display time with a variable step: 10s while under 60s, 60s at 60s and above; clamped to 10s–10min
- **I** shows a photo info overlay (filename, capture date, folder type, tags, path) for 10s
- **?** shows a keyboard shortcut reference for 10s
- All shortcuts except ←/→ show a 3s feedback overlay so the action is visible
- Default display time changed from **8s → 30s** (frontend fallback + `appsettings.example.json`)
- New reusable `useOverlayMessage` hook (designed to be the confirmation channel for future write-actions: starring, marking for deletion, rotating, etc.)
- Ken Burns animation duration follows the display time automatically — no extra code needed

No backend changes; the info panel uses the `PhotoDto` fields already available client-side.

## Test plan

- [ ] `pnpm run lint && pnpm run test && pnpm run build` — all green
- [ ] Arrow keys navigate with no overlay
- [ ] Space toggles play/pause with a 3s overlay showing Paused / Playing
- [ ] `+` from 30s steps 30→40→50→60→120→180…; `−` reverses symmetrically
- [ ] Steps clamp at 10s (min) and 10m / 600s (max) with overlay showing the applied value
- [ ] Ken Burns speed visibly changes when display time changes (compare the next photo's animation vs prior)
- [ ] `I` shows photo info for 10s then disappears
- [ ] `?` shows shortcut list for 10s then disappears
- [ ] Fresh load starts at 30s

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)