### PR TITLE
feat: index info panel with folder photo counts and sidecar size

### DIFF
--- a/src/PhotoOrganizer.Application/Index/IndexStatsDto.cs
+++ b/src/PhotoOrganizer.Application/Index/IndexStatsDto.cs
@@ -1,0 +1,17 @@
+namespace PhotoOrganizer.Application.Index;
+
+public sealed record IndexStatsDto
+{
+    public required bool Complete { get; init; }
+    public required int TotalPhotoCount { get; init; }
+    public required long SidecarSizeBytes { get; init; }
+    public required IReadOnlyList<FolderStatsDto> Folders { get; init; }
+}
+
+public sealed record FolderStatsDto
+{
+    public required string Path { get; init; }
+    public required string Label { get; init; }
+    public required string Type { get; init; }
+    public required int PhotoCount { get; init; }
+}

--- a/src/PhotoOrganizer.Server/Program.cs
+++ b/src/PhotoOrganizer.Server/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using PhotoOrganizer.Application;
 using PhotoOrganizer.Application.Crawler;
 using PhotoOrganizer.Application.Folders;
+using PhotoOrganizer.Application.Index;
 using PhotoOrganizer.Application.Photos;
 using PhotoOrganizer.Domain.Interfaces;
 using PhotoOrganizer.Infrastructure.Crawler;
@@ -147,6 +148,67 @@ app.MapGet("/api/config", (IOptions<PhotoOrganizerSettings> options) =>
 // Useful for the UI to show a progress hint, and for integration tests to know when to assert.
 app.MapGet("/api/index/status", (PhotoIndex index) =>
     Results.Ok(new { complete = index.IsComplete, count = index.Count }));
+
+app.MapGet("/api/index/stats", (PhotoIndex index) =>
+{
+    var photos = index.SnapshotPhotos();
+    var folders = index.SnapshotFolders();
+
+    // Assign each photo to its nearest-ancestor source folder (mirrors the crawler's unit logic).
+    var folderPathSet = folders.Select(f => f.Path).ToHashSet(StringComparer.OrdinalIgnoreCase);
+    var photoCounts = folders.ToDictionary(f => f.Path, _ => 0, StringComparer.OrdinalIgnoreCase);
+
+    foreach (var photo in photos)
+    {
+        var dir = Path.GetDirectoryName(photo.FilePath) ?? string.Empty;
+        var current = dir;
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (folderPathSet.Contains(current))
+            {
+                photoCounts[current]++;
+                break;
+            }
+            var parent = Path.GetDirectoryName(current);
+            if (parent == current) break;
+            current = parent ?? string.Empty;
+        }
+    }
+
+    // Sum sidecar file sizes for all known photos and folders without a full tree scan.
+    long sidecarBytes = 0;
+    foreach (var photo in photos)
+    {
+        var sidecarPath = photo.FilePath + ".meta.json";
+        try { if (File.Exists(sidecarPath)) sidecarBytes += new FileInfo(sidecarPath).Length; }
+        catch { /* best-effort */ }
+    }
+    foreach (var folder in folders)
+    {
+        var folderSidecar = Path.Combine(folder.Path, "_folder.json");
+        try { if (File.Exists(folderSidecar)) sidecarBytes += new FileInfo(folderSidecar).Length; }
+        catch { /* best-effort */ }
+    }
+
+    var dto = new IndexStatsDto
+    {
+        Complete = index.IsComplete,
+        TotalPhotoCount = photos.Count,
+        SidecarSizeBytes = sidecarBytes,
+        Folders = folders
+            .OrderBy(f => f.Label, StringComparer.CurrentCultureIgnoreCase)
+            .Select(f => new FolderStatsDto
+            {
+                Path = f.Path,
+                Label = f.Label,
+                Type = f.Type.ToString(),
+                PhotoCount = photoCounts[f.Path]
+            })
+            .ToList()
+    };
+
+    return Results.Ok(dto);
+});
 
 app.MapPost("/api/crawler/start", async ([FromBody] StartCrawlRequest request, ICrawlerService service) =>
 {

--- a/src/PhotoOrganizer.Web/src/App.css
+++ b/src/PhotoOrganizer.Web/src/App.css
@@ -398,7 +398,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  max-width: min(560px, 90vw);
+  max-width: min(680px, 90vw);
   width: max-content;
   background: rgba(0, 0, 0, 0.65);
   backdrop-filter: blur(8px);
@@ -482,4 +482,72 @@
   padding: 1px 5px;
   font-family: var(--mono, monospace);
   font-size: 12px;
+}
+
+/* Index button in controls bar */
+.slideshow-index-ctrl {
+  font-size: 18px;
+  margin-left: 8px;
+  opacity: 0.6;
+}
+
+/* Index info panel inside the overlay */
+.slideshow-index-panel {
+  min-width: 320px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.slideshow-index-loading {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 13px;
+}
+
+.slideshow-index-summary {
+  margin-bottom: 16px;
+}
+
+.slideshow-index-table {
+  border-collapse: collapse;
+  font-size: 13px;
+  width: 100%;
+}
+
+.slideshow-index-table th {
+  text-align: left;
+  padding: 0 0 6px;
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 500;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.slideshow-index-table td {
+  padding: 5px 0;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  color: #fff;
+}
+
+.slideshow-index-label {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 12px;
+}
+
+.slideshow-index-type {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 12px;
+  padding-right: 12px;
+  white-space: nowrap;
+}
+
+.slideshow-index-count {
+  text-align: right;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.85);
 }

--- a/src/PhotoOrganizer.Web/src/api/client.ts
+++ b/src/PhotoOrganizer.Web/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ConfigDto, FolderDto, PhotoDto, PhotoPageDto, PhotoQuery } from './types';
+import type { ConfigDto, FolderDto, IndexStatsDto, PhotoDto, PhotoPageDto, PhotoQuery } from './types';
 
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(url);
@@ -34,6 +34,10 @@ export async function getPhoto(id: string): Promise<PhotoDto | null> {
 
 export async function getConfig(): Promise<ConfigDto> {
   return fetchJson('/api/config');
+}
+
+export async function getIndexStats(): Promise<IndexStatsDto> {
+  return fetchJson('/api/index/stats');
 }
 
 export async function getSlideshowNext(): Promise<PhotoDto | null> {

--- a/src/PhotoOrganizer.Web/src/api/types.ts
+++ b/src/PhotoOrganizer.Web/src/api/types.ts
@@ -52,3 +52,17 @@ export interface ConfigDto {
   scanRoots: string[];
   slideshow: SlideshowConfigDto;
 }
+
+export interface FolderStatsDto {
+  path: string;
+  label: string;
+  type: FolderType;
+  photoCount: number;
+}
+
+export interface IndexStatsDto {
+  complete: boolean;
+  totalPhotoCount: number;
+  sidecarSizeBytes: number;
+  folders: FolderStatsDto[];
+}

--- a/src/PhotoOrganizer.Web/src/components/IndexInfoPanel.tsx
+++ b/src/PhotoOrganizer.Web/src/components/IndexInfoPanel.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from 'react';
+import { getIndexStats } from '../api/client';
+import type { IndexStatsDto } from '../api/types';
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function IndexInfoPanel() {
+  const [stats, setStats] = useState<IndexStatsDto | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    getIndexStats()
+      .then(setStats)
+      .catch(() => setError(true));
+  }, []);
+
+  if (error) {
+    return <div className="slideshow-index-panel">Failed to load index info.</div>;
+  }
+
+  if (!stats) {
+    return <div className="slideshow-index-panel slideshow-index-loading">Loading…</div>;
+  }
+
+  return (
+    <div className="slideshow-index-panel">
+      <h3 className="slideshow-shortcut-title">Index {stats.complete ? '' : '(indexing…)'}</h3>
+
+      <dl className="slideshow-info-dl slideshow-index-summary">
+        <dt>Photos</dt>
+        <dd>{stats.totalPhotoCount.toLocaleString()}</dd>
+        <dt>Sidecar size</dt>
+        <dd>{formatBytes(stats.sidecarSizeBytes)}</dd>
+        <dt>Folders</dt>
+        <dd>{stats.folders.length.toLocaleString()}</dd>
+      </dl>
+
+      {stats.folders.length > 0 && (
+        <table className="slideshow-index-table">
+          <thead>
+            <tr>
+              <th>Folder</th>
+              <th>Type</th>
+              <th className="slideshow-index-count">Photos</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.folders.map(f => (
+              <tr key={f.path}>
+                <td className="slideshow-index-label" title={f.path}>{f.label}</td>
+                <td className="slideshow-index-type">{f.type}</td>
+                <td className="slideshow-index-count">{f.photoCount.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/PhotoOrganizer.Web/src/components/ShortcutHelp.tsx
+++ b/src/PhotoOrganizer.Web/src/components/ShortcutHelp.tsx
@@ -8,6 +8,7 @@ export function ShortcutHelp() {
           <tr><td><kbd>Space</kbd></td><td>Play / Pause</td></tr>
           <tr><td><kbd>+</kbd> / <kbd>−</kbd></td><td>Increase / Decrease display time</td></tr>
           <tr><td><kbd>I</kbd></td><td>Show photo info</td></tr>
+          <tr><td><kbd>X</kbd></td><td>Show index</td></tr>
           <tr><td><kbd>?</kbd></td><td>Show this help</td></tr>
           <tr><td><kbd>Esc</kbd></td><td>Exit slideshow</td></tr>
         </tbody>

--- a/src/PhotoOrganizer.Web/src/hooks/useKeyboardNavigation.ts
+++ b/src/PhotoOrganizer.Web/src/hooks/useKeyboardNavigation.ts
@@ -7,6 +7,7 @@ export interface KeyboardNavigationConfig {
   onIncreaseDuration?: () => void;
   onDecreaseDuration?: () => void;
   onShowInfo?: () => void;
+  onShowIndex?: () => void;
   onShowHelp?: () => void;
   onExit?: () => void;
   enabled?: boolean;
@@ -19,6 +20,7 @@ export function useKeyboardNavigation({
   onIncreaseDuration,
   onDecreaseDuration,
   onShowInfo,
+  onShowIndex,
   onShowHelp,
   onExit,
   enabled = true,
@@ -64,6 +66,11 @@ export function useKeyboardNavigation({
         event.preventDefault();
         onShowInfo?.();
         break;
+      case 'x':
+      case 'X':
+        event.preventDefault();
+        onShowIndex?.();
+        break;
       case '?':
       case '/':
         event.preventDefault();
@@ -74,7 +81,7 @@ export function useKeyboardNavigation({
         onExit?.();
         break;
     }
-  }, [enabled, onNext, onPrevious, onTogglePause, onIncreaseDuration, onDecreaseDuration, onShowInfo, onShowHelp, onExit]);
+  }, [enabled, onNext, onPrevious, onTogglePause, onIncreaseDuration, onDecreaseDuration, onShowInfo, onShowIndex, onShowHelp, onExit]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/src/PhotoOrganizer.Web/src/pages/SlideshowPage.tsx
+++ b/src/PhotoOrganizer.Web/src/pages/SlideshowPage.tsx
@@ -7,6 +7,7 @@ import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
 import { useOverlayMessage } from '../hooks/useOverlayMessage';
 import { SlideshowImage } from '../components/SlideshowImage';
 import { PhotoInfoPanel } from '../components/PhotoInfoPanel';
+import { IndexInfoPanel } from '../components/IndexInfoPanel';
 import { ShortcutHelp } from '../components/ShortcutHelp';
 import { generateKenBurnsConfig } from '../utils/kenBurns';
 import { nextDuration, formatDuration } from '../utils/duration';
@@ -124,6 +125,11 @@ export default function SlideshowPage() {
     );
   }, [currentDisplay, intervalSeconds, overlay]);
 
+  // Index info
+  const handleShowIndex = useCallback(() => {
+    overlay.showMessage(<IndexInfoPanel />, INFO_DURATION_MS);
+  }, [overlay]);
+
   // Shortcut help
   const handleShowHelp = useCallback(() => {
     overlay.showMessage(<ShortcutHelp />, INFO_DURATION_MS);
@@ -136,6 +142,7 @@ export default function SlideshowPage() {
     onIncreaseDuration: handleIncreaseDuration,
     onDecreaseDuration: handleDecreaseDuration,
     onShowInfo: handleShowInfo,
+    onShowIndex: handleShowIndex,
     onShowHelp: handleShowHelp,
     onExit: handleExit,
   });
@@ -193,6 +200,7 @@ export default function SlideshowPage() {
             {slideshow.paused ? '▶' : '⏸'}
           </button>
           <button className="slideshow-control-btn" onClick={slideshow.next} title="Next (→)">›</button>
+          <button className="slideshow-control-btn slideshow-index-ctrl" onClick={handleShowIndex} title="Index (X)">≡</button>
           <button className="slideshow-control-btn slideshow-exit-ctrl" onClick={handleExit} title="Exit (Esc)">✕</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Adds  endpoint returning per-folder photo counts and total sidecar file size in bytes
- New  component displays all indexed folders (label, type, photo count) plus aggregate stats (total photos, sidecar MB)
-  keyboard shortcut and  control-bar button in the slideshow open the panel in the existing overlay
- Shortcut help updated to list the new  key

## Test plan

- [ ] Press  in the slideshow — index panel opens showing folder list and aggregate stats
- [ ] Click the  button in the controls bar — same panel opens
- [ ] Panel shows correct photo counts per folder and sidecar size
- [ ] Panel shows "indexing…" label while index is still building
- [ ]  shortcut help lists the  key
- [ ] All existing tests pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)