### PR TITLE
fix: set inline Content-Disposition and broaden image MIME types

### DIFF
--- a/src/PhotoOrganizer.Server/Program.cs
+++ b/src/PhotoOrganizer.Server/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 using PhotoOrganizer.Application;
 using PhotoOrganizer.Application.Crawler;
 using PhotoOrganizer.Application.Folders;
@@ -102,11 +103,18 @@ app.MapGet("/api/photos/{id:guid}", async (Guid id, IPhotoService service) =>
     return photo is null ? Results.NotFound() : Results.Ok(photo);
 });
 
-app.MapGet("/api/photos/{id:guid}/image", async (Guid id, IPhotoRepository repository, IImageTranscoder transcoder, CancellationToken ct) =>
+app.MapGet("/api/photos/{id:guid}/image", async (Guid id, HttpContext httpContext, IPhotoRepository repository, IImageTranscoder transcoder, CancellationToken ct) =>
 {
     var photo = await repository.GetByIdAsync(id);
     if (photo is null)
         return Results.NotFound();
+
+    // Set Content-Disposition: inline so the browser renders the image inline while still
+    // knowing the file's real name (e.g. when saving). SetHttpFileName handles non-ASCII
+    // names by emitting the RFC 5987 filename* parameter when required.
+    var disposition = new ContentDispositionHeaderValue("inline");
+    disposition.SetHttpFileName(photo.FileName);
+    httpContext.Response.Headers.ContentDisposition = disposition.ToString();
 
     // HEIC/HEIF cannot be natively decoded by most browsers; transcode to JPEG on the fly.
     if (transcoder.IsTranscodable(photo.FilePath))
@@ -118,9 +126,12 @@ app.MapGet("/api/photos/{id:guid}/image", async (Guid id, IPhotoRepository repos
     var contentType = Path.GetExtension(photo.FilePath).ToLowerInvariant() switch
     {
         ".jpg" or ".jpeg" => "image/jpeg",
-        ".png" => "image/png",
+        ".png"            => "image/png",
+        ".gif"            => "image/gif",
+        ".webp"           => "image/webp",
+        ".bmp"            => "image/bmp",
         ".tiff" or ".tif" => "image/tiff",
-        _ => "application/octet-stream"
+        _                 => "application/octet-stream"
     };
 
     return Results.File(photo.FilePath, contentType);

--- a/tests/PhotoOrganizer.EndToEnd.Tests/HeicTranscodingTests.cs
+++ b/tests/PhotoOrganizer.EndToEnd.Tests/HeicTranscodingTests.cs
@@ -67,6 +67,13 @@ public class HeicTranscodingTests
         Assert.AreEqual("image/jpeg", imageResponse.Content.Headers.ContentType?.MediaType,
             "HEIC should be transcoded to JPEG so all browsers can display it");
 
+        // Verify the Content-Disposition header is inline and carries a real filename.
+        var contentDisposition = imageResponse.Content.Headers.ContentDisposition;
+        Assert.AreEqual("inline", contentDisposition?.DispositionType,
+            "Image should be served inline so browsers render it in-page");
+        Assert.IsFalse(string.IsNullOrEmpty(contentDisposition?.FileName),
+            "Download name should not be empty");
+
         // Verify the response body is a valid JPEG (starts with the JPEG magic bytes FF D8 FF).
         var bytes = await imageResponse.Content.ReadAsByteArrayAsync();
         Assert.IsTrue(bytes.Length >= 3, "Image response body is too short");


### PR DESCRIPTION
## Summary

- Set  on all  responses so the framework no longer logs an empty download name, and saving the image picks up the real filename
- Broaden the content-type switch to include , , and ;  remains the fallback for unrecognised formats
- Extend  to assert the response is  with a non-empty filename

## Test plan

- [x]   Determining projects to restore...
  All projects are up-to-date for restore.
  PhotoOrganizer.FixtureGenerator -> /Users/magnus/private/repos/photo-organizer/tools/PhotoOrganizer.FixtureGenerator/bin/Debug/net10.0/PhotoOrganizer.FixtureGenerator.dll
  PhotoOrganizer.Domain -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Domain/bin/Debug/net10.0/PhotoOrganizer.Domain.dll
  PhotoOrganizer.Crawler -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Crawler/bin/Debug/net10.0/PhotoOrganizer.Crawler.dll
  PhotoOrganizer.Crawler.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Crawler.Tests/bin/Debug/net10.0/PhotoOrganizer.Crawler.Tests.dll
  PhotoOrganizer.Application -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Application/bin/Debug/net10.0/PhotoOrganizer.Application.dll
  PhotoOrganizer.Application.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Application.Tests/bin/Debug/net10.0/PhotoOrganizer.Application.Tests.dll
  PhotoOrganizer.Infrastructure -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Infrastructure/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.dll
  PhotoOrganizer.Infrastructure.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Infrastructure.Tests/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.Tests.dll
  PhotoOrganizer.Server -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Server/bin/Debug/net10.0/PhotoOrganizer.Server.dll
  PhotoOrganizer.Server.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Server.Tests/bin/Debug/net10.0/PhotoOrganizer.Server.Tests.dll
  PhotoOrganizer.EndToEnd.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.EndToEnd.Tests/bin/Debug/net10.0/PhotoOrganizer.EndToEnd.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:20.26 — clean
- [x]   Determining projects to restore...
  All projects are up-to-date for restore.
  PhotoOrganizer.Domain -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Domain/bin/Debug/net10.0/PhotoOrganizer.Domain.dll
  PhotoOrganizer.Application -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Application/bin/Debug/net10.0/PhotoOrganizer.Application.dll
  PhotoOrganizer.Crawler -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Crawler/bin/Debug/net10.0/PhotoOrganizer.Crawler.dll
  PhotoOrganizer.Infrastructure -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Infrastructure/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.dll
  PhotoOrganizer.Application.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Application.Tests/bin/Debug/net10.0/PhotoOrganizer.Application.Tests.dll
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Application.Tests/bin/Debug/net10.0/PhotoOrganizer.Application.Tests.dll (.NETCoreApp,Version=v10.0)
  PhotoOrganizer.Crawler.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Crawler.Tests/bin/Debug/net10.0/PhotoOrganizer.Crawler.Tests.dll
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Crawler.Tests/bin/Debug/net10.0/PhotoOrganizer.Crawler.Tests.dll (.NETCoreApp,Version=v10.0)
  PhotoOrganizer.Infrastructure.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Infrastructure.Tests/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.Tests.dll
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Infrastructure.Tests/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.Tests.dll (.NETCoreApp,Version=v10.0)
  PhotoOrganizer.Server -> /Users/magnus/private/repos/photo-organizer/src/PhotoOrganizer.Server/bin/Debug/net10.0/PhotoOrganizer.Server.dll
  PhotoOrganizer.Server.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Server.Tests/bin/Debug/net10.0/PhotoOrganizer.Server.Tests.dll
  PhotoOrganizer.EndToEnd.Tests -> /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.EndToEnd.Tests/bin/Debug/net10.0/PhotoOrganizer.EndToEnd.Tests.dll
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Server.Tests/bin/Debug/net10.0/PhotoOrganizer.Server.Tests.dll (.NETCoreApp,Version=v10.0)
Test run for /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.EndToEnd.Tests/bin/Debug/net10.0/PhotoOrganizer.EndToEnd.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.
A total of 1 test files matched the specified pattern.
A total of 1 test files matched the specified pattern.
A total of 1 test files matched the specified pattern.
A total of 1 test files matched the specified pattern.
No test matches the given testcase filter `TestCategory=Integration` in /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Application.Tests/bin/Debug/net10.0/PhotoOrganizer.Application.Tests.dll
No test matches the given testcase filter `TestCategory=Integration` in /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Infrastructure.Tests/bin/Debug/net10.0/PhotoOrganizer.Infrastructure.Tests.dll
No test matches the given testcase filter `TestCategory=Integration` in /Users/magnus/private/repos/photo-organizer/tests/PhotoOrganizer.Crawler.Tests/bin/Debug/net10.0/PhotoOrganizer.Crawler.Tests.dll




Passed!  - Failed:     0, Passed:    11, Skipped:     0, Total:    11, Duration: 2 s - PhotoOrganizer.EndToEnd.Tests.dll (net10.0)

Passed!  - Failed:     0, Passed:     8, Skipped:     0, Total:     8, Duration: 2 s - PhotoOrganizer.Server.Tests.dll (net10.0) — all 11 end-to-end tests pass, including the new Content-Disposition assertions

Closes #47