### PR TITLE
fix: remove InvalidateCacheAsync / PhotoIndex.Clear() footgun

### DIFF
--- a/src/PhotoOrganizer.Domain/Interfaces/IPhotoRepository.cs
+++ b/src/PhotoOrganizer.Domain/Interfaces/IPhotoRepository.cs
@@ -4,5 +4,4 @@ public interface IPhotoRepository
 {
     Task<IReadOnlyList<Photo>> GetAllPhotosAsync();
     Task<Photo?> GetByIdAsync(Guid id);
-    Task InvalidateCacheAsync();
 }

--- a/src/PhotoOrganizer.Infrastructure/Indexing/IndexPhotoRepository.cs
+++ b/src/PhotoOrganizer.Infrastructure/Indexing/IndexPhotoRepository.cs
@@ -14,10 +14,4 @@ public sealed class IndexPhotoRepository(PhotoIndex index) : IPhotoRepository
 
     public Task<Photo?> GetByIdAsync(Guid id) =>
         Task.FromResult(index.GetById(id));
-
-    public Task InvalidateCacheAsync()
-    {
-        index.Clear();
-        return Task.CompletedTask;
-    }
 }

--- a/src/PhotoOrganizer.Infrastructure/Indexing/PhotoIndex.cs
+++ b/src/PhotoOrganizer.Infrastructure/Indexing/PhotoIndex.cs
@@ -39,12 +39,4 @@ public sealed class PhotoIndex
 
     /// <summary>Marks the index as fully built and ready.</summary>
     public void MarkComplete() => _isComplete = true;
-
-    /// <summary>Clears all entries and resets the completion flag (used by InvalidateCacheAsync).</summary>
-    public void Clear()
-    {
-        _photos.Clear();
-        _folders.Clear();
-        _isComplete = false;
-    }
 }

--- a/src/PhotoOrganizer.Infrastructure/Storage/FileSystemPhotoRepository.cs
+++ b/src/PhotoOrganizer.Infrastructure/Storage/FileSystemPhotoRepository.cs
@@ -57,20 +57,6 @@ public sealed class FileSystemPhotoRepository : IPhotoRepository
         return _cacheById!.GetValueOrDefault(id);
     }
 
-    public async Task InvalidateCacheAsync()
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            _cache = null;
-            _cacheById = null;
-        }
-        finally
-        {
-            _lock.Release();
-        }
-    }
-
     private async Task<List<Photo>> LoadPhotosAsync()
     {
         var folders = await _folderRepository.GetAllFoldersAsync();

--- a/tests/PhotoOrganizer.Infrastructure.Tests/FileSystemPhotoRepositoryTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/FileSystemPhotoRepositoryTests.cs
@@ -106,16 +106,13 @@ public sealed class FileSystemPhotoRepositoryTests
     }
 
     [TestMethod]
-    public async Task GetAllPhotos_DeterministicId_StableAcrossRepeatCalls()
+    public async Task GetAllPhotos_DeterministicId_StableAcrossIndependentLoads()
     {
         await WriteFolderSidecar(_tempDir.FullName);
         WritePhotoFile(_tempDir.FullName, "photo.jpg");
 
-        var repo = CreatePhotoRepository(_tempDir.FullName);
-        var photos1 = await repo.GetAllPhotosAsync();
-
-        await repo.InvalidateCacheAsync();
-        var photos2 = await repo.GetAllPhotosAsync();
+        var photos1 = await CreatePhotoRepository(_tempDir.FullName).GetAllPhotosAsync();
+        var photos2 = await CreatePhotoRepository(_tempDir.FullName).GetAllPhotosAsync();
 
         Assert.AreEqual(photos1[0].Id, photos2[0].Id);
     }
@@ -171,26 +168,7 @@ public sealed class FileSystemPhotoRepositoryTests
         Assert.IsNull(result);
     }
 
-    [TestMethod]
-    public async Task InvalidateCache_ForcesReload()
-    {
-        await WriteFolderSidecar(_tempDir.FullName);
-        WritePhotoFile(_tempDir.FullName, "photo.jpg");
-
-        var repo = CreatePhotoRepository(_tempDir.FullName);
-        var before = await repo.GetAllPhotosAsync();
-
-        // Add a new photo after initial load
-        WritePhotoFile(_tempDir.FullName, "photo2.jpg");
-        await repo.InvalidateCacheAsync();
-
-        var after = await repo.GetAllPhotosAsync();
-
-        Assert.AreEqual(1, before.Count);
-        Assert.AreEqual(2, after.Count);
-    }
-
-    [TestMethod]
+[TestMethod]
     public async Task GetAllPhotos_SkipsReparsePointSubdirectory_AndStillFindsPhotos()
     {
         await WriteFolderSidecar(_tempDir.FullName);

--- a/tests/PhotoOrganizer.Infrastructure.Tests/Indexing/PhotoIndexTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/Indexing/PhotoIndexTests.cs
@@ -106,19 +106,6 @@ public sealed class PhotoIndexTests
         Assert.IsTrue(index.IsComplete);
     }
 
-    [TestMethod]
-    public void Clear_ResetsCountAndIsComplete()
-    {
-        var index = new PhotoIndex();
-        index.AddPhoto(MakePhoto(@"C:\photos\img001.jpg"));
-        index.MarkComplete();
-
-        index.Clear();
-
-        Assert.AreEqual(0, index.Count);
-        Assert.IsFalse(index.IsComplete);
-    }
-
     // ─── Thread safety ────────────────────────────────────────────────────────
 
     [TestMethod]

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceCursorTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceCursorTests.cs
@@ -285,6 +285,5 @@ public sealed class PhotoServiceCursorTests
 
         public Task<IReadOnlyList<Photo>> GetAllPhotosAsync() => Task.FromResult(_photos);
         public Task<Photo?> GetByIdAsync(Guid id) => Task.FromResult(_photos.FirstOrDefault(p => p.Id == id));
-        public Task InvalidateCacheAsync() => Task.CompletedTask;
     }
 }

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceDisplayOrderTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceDisplayOrderTests.cs
@@ -124,6 +124,5 @@ public sealed class PhotoServiceDisplayOrderTests
 
         public Task<IReadOnlyList<Photo>> GetAllPhotosAsync() => Task.FromResult(_photos);
         public Task<Photo?> GetByIdAsync(Guid id) => Task.FromResult(_photos.FirstOrDefault(p => p.Id == id));
-        public Task InvalidateCacheAsync() => Task.CompletedTask;
     }
 }

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceDisplayableFilterTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceDisplayableFilterTests.cs
@@ -200,6 +200,5 @@ public sealed class PhotoServiceDisplayableFilterTests
 
         public Task<IReadOnlyList<Photo>> GetAllPhotosAsync() => Task.FromResult(_photos);
         public Task<Photo?> GetByIdAsync(Guid id) => Task.FromResult(_photos.FirstOrDefault(p => p.Id == id));
-        public Task InvalidateCacheAsync() => Task.CompletedTask;
     }
 }

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceFilterTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceFilterTests.cs
@@ -389,6 +389,5 @@ public sealed class PhotoServiceFilterTests
 
         public Task<IReadOnlyList<Photo>> GetAllPhotosAsync() => Task.FromResult(_photos);
         public Task<Photo?> GetByIdAsync(Guid id) => Task.FromResult(_photos.FirstOrDefault(p => p.Id == id));
-        public Task InvalidateCacheAsync() => Task.CompletedTask;
     }
 }

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceVersionsTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceVersionsTests.cs
@@ -108,6 +108,5 @@ public sealed class PhotoServiceVersionsTests
 
         public Task<IReadOnlyList<Photo>> GetAllPhotosAsync() => Task.FromResult(_photos);
         public Task<Photo?> GetByIdAsync(Guid id) => Task.FromResult(_photos.FirstOrDefault(p => p.Id == id));
-        public Task InvalidateCacheAsync() => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary

- Removes `InvalidateCacheAsync` from `IPhotoRepository` and both implementations (`IndexPhotoRepository`, `FileSystemPhotoRepository`) — no production caller existed
- Removes `PhotoIndex.Clear()` — the only caller was `IndexPhotoRepository.InvalidateCacheAsync`; calling it on a live index would have silently emptied the index with no rebuild path
- Removes/updates tests that exercised these methods; `GetAllPhotos_DeterministicId_StableAcrossRepeatCalls` is rewritten to use two independent repo instances instead of cache invalidation

## Test plan

- [ ] `dotnet build` passes with 0 warnings
- [ ] `dotnet test --filter "TestCategory!=Integration"` passes (221 tests)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)