### PR TITLE
fix: make Ken Burns effect visibly perceptible (issue #65)

### DIFF
--- a/src/PhotoOrganizer.Web/src/App.css
+++ b/src/PhotoOrganizer.Web/src/App.css
@@ -307,7 +307,7 @@
 
 /* Ken Burns animation via CSS custom properties */
 .slideshow-image.ken-burns {
-  animation: ken-burns var(--kb-duration, 8s) ease-in-out forwards;
+  animation: ken-burns var(--kb-duration, 8s) linear forwards;
   transform-origin: center center;
 }
 

--- a/src/PhotoOrganizer.Web/src/test/kenBurns.test.ts
+++ b/src/PhotoOrganizer.Web/src/test/kenBurns.test.ts
@@ -10,10 +10,10 @@ describe('generateKenBurnsConfig', () => {
       const { scaleFrom, scaleTo } = cfg;
       const small = Math.min(scaleFrom, scaleTo);
       const large = Math.max(scaleFrom, scaleTo);
-      expect(small).toBeGreaterThanOrEqual(1.08);
-      expect(small).toBeLessThanOrEqual(1.12);
-      expect(large).toBeGreaterThanOrEqual(1.18);
-      expect(large).toBeLessThanOrEqual(1.28);
+      expect(small).toBeGreaterThanOrEqual(1.0);
+      expect(small).toBeLessThanOrEqual(1.05);
+      expect(large).toBeGreaterThanOrEqual(1.22);
+      expect(large).toBeLessThanOrEqual(1.30);
     }
   });
 

--- a/src/PhotoOrganizer.Web/src/utils/kenBurns.ts
+++ b/src/PhotoOrganizer.Web/src/utils/kenBurns.ts
@@ -16,12 +16,12 @@ export function generateKenBurnsConfig(intervalMs: number): KenBurnsConfig {
   // Random zoom direction: in or out
   const zoomIn = Math.random() > 0.5;
 
-  // Stronger scale range: 1.08-1.12 to 1.18-1.28
-  const scaleSmall = randomInRange(1.08, 1.12);
-  const scaleLarge = randomInRange(1.18, 1.28);
+  // Scale range: 1.0-1.05 to 1.22-1.30 (~22-30% total zoom, clearly perceptible)
+  const scaleSmall = randomInRange(1.0, 1.05);
+  const scaleLarge = randomInRange(1.22, 1.30);
 
-  // Random pan direction with randomized amount (3-6%)
-  const panAmount = randomInRange(3, 6);
+  // Random pan direction with randomized amount (8-14%)
+  const panAmount = randomInRange(8, 14);
   const panDirections = [
     { x: panAmount, y: 0 },                           // right
     { x: -panAmount, y: 0 },                          // left
@@ -34,7 +34,7 @@ export function generateKenBurnsConfig(intervalMs: number): KenBurnsConfig {
   ];
   const pan = panDirections[Math.floor(Math.random() * panDirections.length)];
 
-  // Duration slightly overshoots the slideshow interval to avoid freezing at the end
+  // Duration spans the full slide interval so the drift continuously fills the display time
   const duration = intervalMs / 1000;
 
   if (zoomIn) {


### PR DESCRIPTION
## Summary

- Widen scale range from ~10% total zoom to ~22–30% (`scaleSmall` 1.0–1.05, `scaleLarge` 1.22–1.30)
- Increase pan range from 3–6% to 8–14%
- Switch animation easing from `ease-in-out` to `linear` so the drift is constant throughout the slide (previously nearly stationary at both ends)

The easing change is the most impactful fix: `ease-in-out` at a 30s interval spends the first ~8s and last ~8s barely moving, making the effect indistinguishable from a still image.

**Note:** If the effect appears absent, verify macOS Settings → Accessibility → Display → "Reduce motion" is off — that setting intentionally disables Ken Burns.

## Test plan

- [x] `pnpm run test` — all 65 tests pass (updated scale-range assertions)
- [x] `pnpm run lint` — no new errors
- [x] `pnpm run build` — clean build
- [ ] Manual: open slideshow, confirm each photo visibly zooms/pans over its display time
- [ ] Manual: use `-` key to lower interval and confirm motion stays pleasant at short intervals

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)