### PR TITLE
fix: remove dead slideshow retry/backoff, add fetch cancellation and tests

### DIFF
--- a/src/PhotoOrganizer.Web/src/api/client.ts
+++ b/src/PhotoOrganizer.Web/src/api/client.ts
@@ -1,7 +1,11 @@
 import type { ConfigDto, FolderDto, IndexStatusDto, IndexStatsDto, PhotoDto, PhotoPageDto, PhotoQuery } from './types';
 
-async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+const REQUEST_TIMEOUT_MS = 30_000;
+
+async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const combined = signal ? AbortSignal.any([signal, timeout]) : timeout;
+  const res = await fetch(url, { signal: combined });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}: ${url}`);
   return res.json() as Promise<T>;
 }
@@ -14,7 +18,7 @@ export async function getFolders(): Promise<FolderDto[]> {
   return fetchJson('/api/folders');
 }
 
-export async function getPhotos(query: PhotoQuery = {}): Promise<PhotoPageDto> {
+export async function getPhotos(query: PhotoQuery = {}, signal?: AbortSignal): Promise<PhotoPageDto> {
   const params = new URLSearchParams();
   if (query.folder) params.set('folder', query.folder);
   if (query.type) params.set('type', query.type);
@@ -27,7 +31,7 @@ export async function getPhotos(query: PhotoQuery = {}): Promise<PhotoPageDto> {
   if (query.cursor !== undefined) params.set('cursor', query.cursor);
   if (query.limit !== undefined) params.set('limit', String(query.limit));
   const qs = params.toString();
-  return fetchJson(`/api/photos${qs ? `?${qs}` : ''}`);
+  return fetchJson(`/api/photos${qs ? `?${qs}` : ''}`, signal);
 }
 
 export async function getIndexStatus(): Promise<IndexStatusDto> {

--- a/src/PhotoOrganizer.Web/src/hooks/useInfinitePhotos.ts
+++ b/src/PhotoOrganizer.Web/src/hooks/useInfinitePhotos.ts
@@ -113,6 +113,8 @@ export function useInfinitePhotos(filters: InfinitePhotosFilters): UseInfinitePh
   const activeKeyRef = useRef<string>('');
   // Set of loaded photo ids for O(1) dedup in mergeNewest.
   const loadedIdsRef = useRef<Set<string>>(new Set());
+  // AbortController for in-flight fetches; replaced on every filter reset and on unmount.
+  const abortRef = useRef<AbortController | null>(null);
 
   const currentKey = filterKey(filters);
 
@@ -122,6 +124,10 @@ export function useInfinitePhotos(filters: InfinitePhotosFilters): UseInfinitePh
 
   // Reset state and fetch the first page whenever filters change.
   useEffect(() => {
+    // Abort any in-flight request from the previous filter set.
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+
     const key = filterKey(filtersRef.current);
     activeKeyRef.current = key;
     nextCursorRef.current = null;
@@ -131,6 +137,10 @@ export function useInfinitePhotos(filters: InfinitePhotosFilters): UseInfinitePh
 
     dispatch({ type: 'reset' });
     fetchPage(key, null);
+
+    return () => {
+      abortRef.current?.abort();
+    };
   }, [currentKey]);
 
   /**
@@ -144,16 +154,19 @@ export function useInfinitePhotos(filters: InfinitePhotosFilters): UseInfinitePh
     dispatch({ type: 'fetch-start' });
 
     const f = filtersRef.current;
-    getPhotos({
-      folder: f.folder || undefined,
-      type: f.type !== 'all' ? f.type : undefined,
-      deduplicated: f.deduplicated,
-      fileName: f.fileName || undefined,
-      dateFrom: f.dateFrom || undefined,
-      dateTo: f.dateTo || undefined,
-      cursor: cursor ?? undefined,
-      limit: PAGE_SIZE,
-    })
+    getPhotos(
+      {
+        folder: f.folder || undefined,
+        type: f.type !== 'all' ? f.type : undefined,
+        deduplicated: f.deduplicated,
+        fileName: f.fileName || undefined,
+        dateFrom: f.dateFrom || undefined,
+        dateTo: f.dateTo || undefined,
+        cursor: cursor ?? undefined,
+        limit: PAGE_SIZE,
+      },
+      abortRef.current?.signal,
+    )
       .then(page => {
         if (activeKeyRef.current !== key) return; // stale response, discard
 
@@ -168,6 +181,9 @@ export function useInfinitePhotos(filters: InfinitePhotosFilters): UseInfinitePh
       })
       .catch(e => {
         if (activeKeyRef.current !== key) return;
+        // An abort is not a user-facing error — it means either filters changed
+        // (activeKeyRef guard above already handles the stale case) or unmount.
+        if (e instanceof DOMException && e.name === 'AbortError') return;
         dispatch({ type: 'fetch-error', error: String(e) });
       })
       .finally(() => {

--- a/src/PhotoOrganizer.Web/src/hooks/useSlideshow.ts
+++ b/src/PhotoOrganizer.Web/src/hooks/useSlideshow.ts
@@ -18,8 +18,6 @@ interface UseSlideshowOptions {
   intervalMs: number;
 }
 
-const MAX_BACKOFF_MS = 30_000;
-
 function preloadImage(url: string): Promise<void> {
   return new Promise((resolve) => {
     const img = new Image();
@@ -43,13 +41,11 @@ export function useSlideshow({ intervalMs }: UseSlideshowOptions): SlideshowStat
   // Timer refs — use setTimeout (rescheduled on each advance) so a late callback
   // doesn't drift and waking from sleep simply reschedules cleanly.
   const timerRef = useRef<number | null>(null);
-  const backoffRef = useRef<number>(1_000);
   const mountedRef = useRef(true);
 
-  // Stable refs to the latest scheduleNext/scheduleRetry so timer callbacks
-  // always invoke the current version even after deps have changed.
+  // Stable ref to the latest scheduleNext so timer callbacks always invoke
+  // the current version even after deps have changed.
   const scheduleNextRef = useRef<() => void>(() => {});
-  const scheduleRetryRef = useRef<() => void>(() => {});
 
   // Cache-ahead: fetch + preload the next photo in the background while the
   // current one is being displayed, so transitions are instant.
@@ -114,7 +110,6 @@ export function useSlideshow({ intervalMs }: UseSlideshowOptions): SlideshowStat
 
       historyRef.current.push(photo);
       pointerRef.current = historyRef.current.length - 1;
-      backoffRef.current = 1_000; // reset backoff on success
       applyPointer();
 
       // Begin fetching the photo after this one while the current one is displayed
@@ -148,28 +143,6 @@ export function useSlideshow({ intervalMs }: UseSlideshowOptions): SlideshowStat
   // Keep refs in sync so timer callbacks always call the latest version.
   // Must be done in an effect (not during render) per react-hooks/refs.
   useEffect(() => { scheduleNextRef.current = scheduleNext; }, [scheduleNext]);
-
-  // Error retry with exponential backoff.
-  // Uses refs for recursive self-calls and for calling scheduleNext to avoid
-  // stale closures.
-  const scheduleRetry = useCallback(() => {
-    clearTimer();
-    timerRef.current = window.setTimeout(() => {
-      if (!mountedRef.current) return;
-      fetchAndAdvance().then(() => {
-        if (mountedRef.current) {
-          if (hasError) {
-            backoffRef.current = Math.min(backoffRef.current * 2, MAX_BACKOFF_MS);
-            scheduleRetryRef.current();
-          } else if (!paused) {
-            scheduleNextRef.current();
-          }
-        }
-      });
-    }, backoffRef.current);
-  }, [clearTimer, fetchAndAdvance, hasError, paused]);
-
-  useEffect(() => { scheduleRetryRef.current = scheduleRetry; }, [scheduleRetry]);
 
   // Initial load
   useEffect(() => {

--- a/src/PhotoOrganizer.Web/src/pages/SlideshowPage.tsx
+++ b/src/PhotoOrganizer.Web/src/pages/SlideshowPage.tsx
@@ -182,7 +182,7 @@ export default function SlideshowPage() {
 
       {/* Subtle error indicator */}
       {slideshow.hasError && (
-        <div className="slideshow-error-indicator" title="Network error — retrying">⚠</div>
+        <div className="slideshow-error-indicator" title="Network error — will retry on next slide">⚠</div>
       )}
 
       {/* Feedback / info overlay */}

--- a/src/PhotoOrganizer.Web/src/test/BrowsePage.test.tsx
+++ b/src/PhotoOrganizer.Web/src/test/BrowsePage.test.tsx
@@ -86,6 +86,7 @@ test('changing the folder filter refetches with the chosen folder', async () => 
   await waitFor(() => {
     expect(client.getPhotos).toHaveBeenCalledWith(
       expect.objectContaining({ folder: '/photos/2024' }),
+      expect.anything(),
     );
   });
 });
@@ -100,6 +101,7 @@ test('changing the type filter refetches with the chosen type', async () => {
   await waitFor(() => {
     expect(client.getPhotos).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'Originals' }),
+      expect.anything(),
     );
   });
 });
@@ -113,6 +115,7 @@ test('unchecking deduplicated only refetches with deduplicated false', async () 
   await waitFor(() => {
     expect(client.getPhotos).toHaveBeenCalledWith(
       expect.objectContaining({ deduplicated: false }),
+      expect.anything(),
     );
   });
 });
@@ -132,6 +135,7 @@ test('typing a filename search refetches with the debounced fileName', async () 
   await waitFor(() => {
     expect(client.getPhotos).toHaveBeenCalledWith(
       expect.objectContaining({ fileName: 'IMG' }),
+      expect.anything(),
     );
   });
 });
@@ -150,6 +154,7 @@ test('setting a date range refetches with dateFrom and dateTo', async () => {
   await waitFor(() => {
     expect(client.getPhotos).toHaveBeenCalledWith(
       expect.objectContaining({ dateFrom: '2024-01-01', dateTo: '2024-12-31' }),
+      expect.anything(),
     );
   });
 });
@@ -161,6 +166,7 @@ test('filters are initialised from URL query params on mount', async () => {
   await waitFor(() => {
     expect(client.getPhotos).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'Originals', deduplicated: false }),
+      expect.anything(),
     );
   });
 });

--- a/src/PhotoOrganizer.Web/src/test/useInfinitePhotos.test.ts
+++ b/src/PhotoOrganizer.Web/src/test/useInfinitePhotos.test.ts
@@ -1,5 +1,8 @@
-import { columnsForWidth, filterKey } from '../hooks/useInfinitePhotos';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { columnsForWidth, filterKey, useInfinitePhotos } from '../hooks/useInfinitePhotos';
 import type { InfinitePhotosFilters } from '../hooks/useInfinitePhotos';
+import * as client from '../api/client';
+import type { PhotoPageDto } from '../api/types';
 
 // ─── filterKey ────────────────────────────────────────────────────────────────
 // Every field in InfinitePhotosFilters must appear in filterKey so that a change
@@ -89,5 +92,151 @@ describe('columnsForWidth', () => {
   test('handles a realistic 1280px viewport with defaults', () => {
     // floor((1280 + 12) / (180 + 12)) = floor(1292 / 192) = 6
     expect(columnsForWidth(1280)).toBe(6);
+  });
+});
+
+// ─── useInfinitePhotos hook behaviour ─────────────────────────────────────────
+
+vi.mock('../api/client', () => ({
+  getPhotos: vi.fn(),
+}));
+
+function makePhoto(id: string) {
+  return {
+    id,
+    filePath: `/photos/${id}.jpg`,
+    fileName: `${id}.jpg`,
+    capturedAt: null,
+    effectiveDate: null,
+    folderType: 'Originals' as const,
+    duplicateGroupId: null,
+    isPreferred: true,
+    tags: [],
+    versions: [],
+  };
+}
+
+function makePage(ids: string[], nextCursor: string | null = null): PhotoPageDto {
+  return { items: ids.map(makePhoto), totalCount: ids.length, page: 1, pageSize: ids.length, nextCursor };
+}
+
+const BASE_FILTERS: InfinitePhotosFilters = {
+  folder: '',
+  type: 'all',
+  deduplicated: false,
+  fileName: '',
+  dateFrom: '',
+  dateTo: '',
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useInfinitePhotos hook', () => {
+  test('loads the first page on mount', async () => {
+    vi.mocked(client.getPhotos).mockResolvedValue(makePage(['a', 'b']));
+
+    const { result } = renderHook(() => useInfinitePhotos(BASE_FILTERS));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.items.map(p => p.id)).toEqual(['a', 'b']);
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  test('stale response is discarded when filter key changes mid-flight', async () => {
+    // Use manual resolve handles so we control when each fetch resolves.
+    let resolveFirst!: (v: PhotoPageDto) => void;
+    let resolveSecond!: (v: PhotoPageDto) => void;
+
+    vi.mocked(client.getPhotos)
+      .mockReturnValueOnce(new Promise<PhotoPageDto>(res => { resolveFirst = res; }))
+      .mockReturnValueOnce(new Promise<PhotoPageDto>(res => { resolveSecond = res; }));
+
+    const filtersA: InfinitePhotosFilters = { ...BASE_FILTERS, folder: 'a' };
+    const filtersB: InfinitePhotosFilters = { ...BASE_FILTERS, folder: 'b' };
+
+    const { result, rerender } = renderHook(
+      ({ filters }: { filters: InfinitePhotosFilters }) => useInfinitePhotos(filters),
+      { initialProps: { filters: filtersA } },
+    );
+
+    // Both filter sets are now mounted; switch to B before A resolves.
+    rerender({ filters: filtersB });
+
+    // Resolve A (stale) — its result must be discarded.
+    await act(async () => { resolveFirst(makePage(['stale-a'])); });
+
+    // Items must remain empty because A's response was stale.
+    expect(result.current.items).toHaveLength(0);
+
+    // Now resolve B (fresh) — its result must be applied.
+    await act(async () => { resolveSecond(makePage(['fresh-b'])); });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.items.map(p => p.id)).toEqual(['fresh-b']);
+  });
+
+  test('mergeNewest prepends only ids not already loaded', async () => {
+    vi.mocked(client.getPhotos).mockResolvedValue(makePage(['a', 'b']));
+
+    const { result } = renderHook(() => useInfinitePhotos(BASE_FILTERS));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // 'b' is already loaded; only 'c' should be prepended.
+    act(() => { result.current.mergeNewest([makePhoto('b'), makePhoto('c')]); });
+
+    expect(result.current.items.map(p => p.id)).toEqual(['c', 'a', 'b']);
+    expect(result.current.totalCount).toBe(3);
+  });
+
+  test('mergeNewest with all-duplicate ids is a no-op', async () => {
+    vi.mocked(client.getPhotos).mockResolvedValue(makePage(['a']));
+
+    const { result } = renderHook(() => useInfinitePhotos(BASE_FILTERS));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const countBefore = result.current.totalCount;
+    act(() => { result.current.mergeNewest([makePhoto('a')]); });
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.totalCount).toBe(countBefore);
+  });
+
+  test('loadMore appends the next page without duplicating the boundary item', async () => {
+    vi.mocked(client.getPhotos)
+      .mockResolvedValueOnce(makePage(['a', 'b'], 'cursor-2'))
+      .mockResolvedValueOnce(makePage(['c', 'd'], null));
+
+    const { result } = renderHook(() => useInfinitePhotos(BASE_FILTERS));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.items.map(p => p.id)).toEqual(['a', 'b']);
+
+    act(() => { result.current.loadMore(); });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Second page appended; no duplicates.
+    expect(result.current.items.map(p => p.id)).toEqual(['a', 'b', 'c', 'd']);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  test('loadMore with an overlapping boundary item deduplicates', async () => {
+    // If the server returns 'b' again on the second page (e.g. concurrent write),
+    // the client-side Set dedup must exclude it.
+    vi.mocked(client.getPhotos)
+      .mockResolvedValueOnce(makePage(['a', 'b'], 'cursor-2'))
+      .mockResolvedValueOnce(makePage(['b', 'c'], null));
+
+    const { result } = renderHook(() => useInfinitePhotos(BASE_FILTERS));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => { result.current.loadMore(); });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.items.map(p => p.id)).toEqual(['a', 'b', 'c']);
   });
 });

--- a/src/PhotoOrganizer.Web/src/test/useSlideshow.test.ts
+++ b/src/PhotoOrganizer.Web/src/test/useSlideshow.test.ts
@@ -1,0 +1,200 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSlideshow } from '../hooks/useSlideshow';
+import * as client from '../api/client';
+
+const INTERVAL_MS = 8_000;
+
+const photo1 = {
+  id: 'photo-1',
+  filePath: '/photos/a.jpg',
+  fileName: 'a.jpg',
+  capturedAt: null,
+  effectiveDate: null,
+  folderType: 'Originals' as const,
+  duplicateGroupId: null,
+  isPreferred: true,
+  tags: [],
+  versions: [],
+};
+
+const photo2 = {
+  id: 'photo-2',
+  filePath: '/photos/b.jpg',
+  fileName: 'b.jpg',
+  capturedAt: null,
+  effectiveDate: null,
+  folderType: 'Originals' as const,
+  duplicateGroupId: null,
+  isPreferred: true,
+  tags: [],
+  versions: [],
+};
+
+vi.mock('../api/client', () => ({
+  getSlideshowNext: vi.fn(),
+  imageUrl: (id: string) => `/api/photos/${id}/image`,
+}));
+
+// Flush the microtask queue without relying on setTimeout (fake-timer-safe).
+async function flushPromises() {
+  await act(async () => {
+    for (let i = 0; i < 20; i++) {
+      await new Promise<void>(resolve => queueMicrotask(resolve));
+    }
+  });
+}
+
+beforeEach(() => {
+  // Only fake timers — leave queueMicrotask/nextTick real so React's scheduler
+  // and act() work correctly.
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('useSlideshow', () => {
+  test('shows the first photo after initial load', async () => {
+    vi.mocked(client.getSlideshowNext).mockResolvedValue(photo1);
+
+    const { result } = renderHook(() => useSlideshow({ intervalMs: INTERVAL_MS }));
+    await flushPromises();
+
+    expect(result.current.status).toBe('ready');
+    expect(result.current.currentPhoto?.id).toBe('photo-1');
+  });
+
+  test('shows empty status when no photos exist (404)', async () => {
+    vi.mocked(client.getSlideshowNext).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useSlideshow({ intervalMs: INTERVAL_MS }));
+    await flushPromises();
+
+    expect(result.current.status).toBe('empty');
+    expect(result.current.currentPhoto).toBeNull();
+  });
+
+  test('auto-advances to the next photo after the interval', async () => {
+    // photo1 (initial fetch) + photo2 (prefetch while photo1 shows) + photo1 (prefetch while photo2 shows)
+    vi.mocked(client.getSlideshowNext)
+      .mockResolvedValueOnce(photo1)
+      .mockResolvedValueOnce(photo2)
+      .mockResolvedValue(photo1);
+
+    const { result } = renderHook(() => useSlideshow({ intervalMs: INTERVAL_MS }));
+    await flushPromises();
+
+    expect(result.current.currentPhoto?.id).toBe('photo-1');
+
+    // Advance past the interval; the hook should consume the prefetched photo2
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    });
+    await flushPromises();
+
+    expect(result.current.currentPhoto?.id).toBe('photo-2');
+  });
+
+  test('pause stops auto-advance across an interval', async () => {
+    vi.mocked(client.getSlideshowNext)
+      .mockResolvedValueOnce(photo1)
+      .mockResolvedValue(photo2);
+
+    const { result } = renderHook(() => useSlideshow({ intervalMs: INTERVAL_MS }));
+    await flushPromises();
+
+    expect(result.current.currentPhoto?.id).toBe('photo-1');
+
+    // Pause
+    act(() => { result.current.togglePause(); });
+    expect(result.current.paused).toBe(true);
+
+    // Advance past the interval — should NOT advance while paused
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS + 1_000);
+    });
+    await flushPromises();
+
+    expect(result.current.currentPhoto?.id).toBe('photo-1');
+  });
+
+  test('resume after pause resumes auto-advance', async () => {
+    vi.mocked(client.getSlideshowNext)
+      .mockResolvedValueOnce(photo1)
+      .mockResolvedValueOnce(photo2)
+      .mockResolvedValue(photo1);
+
+    const { result } = renderHook(() => useSlideshow({ intervalMs: INTERVAL_MS }));
+    await flushPromises();
+
+    // Pause then immediately resume
+    act(() => { result.current.togglePause(); });
+    act(() => { result.current.togglePause(); });
+    expect(result.current.paused).toBe(false);
+
+    // Advance past interval — should advance now
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    });
+    await flushPromises();
+
+    expect(result.current.currentPhoto?.id).toBe('photo-2');
+  });
+
+  test('unmount clears the timer and stops further fetches', async () => {
+    vi.mocked(client.getSlideshowNext)
+      .mockResolvedValueOnce(photo1)
+      .mockResolvedValue(photo2);
+
+    const { unmount } = renderHook(() => useSlideshow({ intervalMs: INTERVAL_MS }));
+    await flushPromises();
+
+    const callCountAfterLoad = vi.mocked(client.getSlideshowNext).mock.calls.length;
+
+    unmount();
+
+    // Advancing timers after unmount must not trigger further fetches
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS * 3);
+    });
+
+    expect(vi.mocked(client.getSlideshowNext).mock.calls.length).toBe(callCountAfterLoad);
+  });
+
+  test('a fetch failure sets hasError but the loop continues on the next interval', async () => {
+    vi.mocked(client.getSlideshowNext)
+      .mockResolvedValueOnce(photo1)   // initial load succeeds
+      .mockRejectedValueOnce(new Error('network error'))  // prefetch fails (ignored)
+      .mockRejectedValueOnce(new Error('network error'))  // next interval fetch fails
+      .mockResolvedValueOnce(photo2)   // prefetch after next interval (ignored here)
+      .mockResolvedValue(photo1);      // recovery fetch succeeds
+
+    const { result } = renderHook(() => useSlideshow({ intervalMs: INTERVAL_MS }));
+    await flushPromises();
+
+    // First photo loaded fine
+    expect(result.current.currentPhoto?.id).toBe('photo-1');
+    expect(result.current.hasError).toBe(false);
+
+    // Advance one interval — fetch fails, hasError should become true
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    });
+    await flushPromises();
+
+    expect(result.current.hasError).toBe(true);
+    // Still showing the last successful photo
+    expect(result.current.currentPhoto?.id).toBe('photo-1');
+
+    // Advance another interval — recovery fetch succeeds, hasError should clear
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    });
+    await flushPromises();
+
+    expect(result.current.hasError).toBe(false);
+    expect(result.current.currentPhoto?.id).toBe('photo-2');
+  });
+});


### PR DESCRIPTION
Closes #62

## Summary

- **Dead code removal**: deleted `scheduleRetry`, `scheduleRetryRef`, `backoffRef`, and `MAX_BACKOFF_MS` from `useSlideshow` — none were reachable (the only caller was the function's own recursion). Interval-paced recovery via `scheduleNext` remains. Fixed the misleading `"Network error — retrying"` tooltip to `"Network error — will retry on next slide"`.
- **Fetch cancellation + timeout**: `fetchJson` now wraps every request with `AbortSignal.timeout(30 s)`, time-bounding all API calls automatically. `getPhotos` accepts an optional `AbortSignal`; `useInfinitePhotos` creates a fresh `AbortController` per filter key, aborting stale in-flight requests on filter change and on unmount. `AbortError`s are silently discarded.
- **Tests**: new `useSlideshow.test.ts` (auto-advance, pause/resume, unmount cleanup, failure recovery); `useInfinitePhotos.test.ts` extended with `renderHook`-based tests for stale-discard, `mergeNewest` dedup, cursor pagination, and boundary dedup; `BrowsePage.test.tsx` updated for the new `signal` argument.

## Test plan

- [x] `pnpm run test` — 78 tests, 0 failures
- [x] `pnpm run lint` — 0 errors, 1 pre-existing warning (`useVirtualizer`)
- [x] `pnpm run build` — types clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)