### PR TITLE
docs: add ADRs 002–009 and ADR process guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,27 +12,27 @@ Reference implementation to draw patterns from: https://github.com/magnusakselvo
 - **Namespace prefix**: `PhotoOrganizer.*`
 - **Backend**: .NET 10, ASP.NET Core, C#; **Frontend**: React + TypeScript, Vite, pnpm
 - **Ports (dev)**: Backend `:6192`, Frontend `:6173`
-- **Image transcoding**: HEIC/HEIF files are transcoded to JPEG on the fly in the `/api/photos/{id}/image` endpoint using `Magick.NET-Q8-AnyCPU` (`MagickImageTranscoder` in `src/PhotoOrganizer.Infrastructure/Imaging/`). The `IImageTranscoder` interface lives in `src/PhotoOrganizer.Domain/Interfaces/`. No caching — each request transcodes fresh; add caching in a future pass.
-- **Displayability**: `DisplayableImageFormats` (`src/PhotoOrganizer.Domain/DisplayableImageFormats.cs`) is the single source of truth for which formats are servable. `PhotoService.ApplyFilters` filters every grid and slideshow listing to displayable photos only (browser-native + transcodable). Non-displayable files (RAW, bare TIFF) are never served in listings but remain downloadable via the version panel's `/api/photos/{id}/image` endpoint. `MagickImageTranscoder` and `DuplicatesStep` both delegate to this helper.
-- **Discoverability**: `SupportedPhotoExtensions` (`src/PhotoOrganizer.Domain/SupportedPhotoExtensions.cs`) is the single source of truth for which extensions the crawler (`FileDiscoverer`) and indexer (`RandomizedSidecarIndexer`) recognise as photos. It is constructed as `DisplayableImageFormats.AllDisplayableExtensions ∪ {RAW/TIFF}`, guaranteeing every displayable/transcodable format is also discoverable. A unit test in `tests/PhotoOrganizer.Application.Tests/SupportedPhotoExtensionsTests.cs` pins the displayable ⊆ discoverable invariant so the two lists cannot silently diverge.
-- **Browse grid pagination**: `/api/photos` supports two pagination modes. (1) **Keyset cursor** (`cursor` + `limit` params, used by the grid): stable, non-overlapping pages ordered newest-first; cursor encodes `(effectiveTimestamp UTC ticks, id)` as base64url. `PhotoService.EncodeCursor`/`DecodeCursor` handle this. Sort has an `Id` tiebreaker (`ThenByDescending(p => p.Id)`) to make cursors deterministic. (2) **Offset** (`page` + `pageSize`): legacy path, kept for the slideshow endpoint and future callers. `PhotoPageDto.NextCursor` is `null` on offset responses.
+- **Image transcoding**: HEIC/HEIF files are transcoded to JPEG on the fly in the `/api/photos/{id}/image` endpoint using `Magick.NET-Q8-AnyCPU` (`MagickImageTranscoder` in `src/PhotoOrganizer.Infrastructure/Imaging/`). The `IImageTranscoder` interface lives in `src/PhotoOrganizer.Domain/Interfaces/`. No caching — each request transcodes fresh (see ADR 006).
+- **Displayability**: `DisplayableImageFormats` (`src/PhotoOrganizer.Domain/DisplayableImageFormats.cs`) is the single source of truth for which formats are servable. `PhotoService.ApplyFilters` filters every grid and slideshow listing to displayable photos only (browser-native + transcodable). Non-displayable files (RAW, bare TIFF) are never served in listings but remain downloadable via the version panel's `/api/photos/{id}/image` endpoint. `MagickImageTranscoder` and `DuplicatesStep` both delegate to this helper (see ADR 007).
+- **Discoverability**: `SupportedPhotoExtensions` (`src/PhotoOrganizer.Domain/SupportedPhotoExtensions.cs`) is the single source of truth for which extensions the crawler (`FileDiscoverer`) and indexer (`RandomizedSidecarIndexer`) recognise as photos. Constructed as `DisplayableImageFormats.AllDisplayableExtensions ∪ {RAW/TIFF}`; `displayable ⊆ discoverable` is pinned by a unit test in `tests/PhotoOrganizer.Application.Tests/SupportedPhotoExtensionsTests.cs` (see ADR 007).
+- **Browse grid pagination**: `/api/photos` supports two modes. (1) **Keyset cursor** (`cursor` + `limit`, used by the grid): stable, non-overlapping pages ordered newest-first; cursor encodes `(effectiveTimestamp UTC ticks, id)` as base64url — `PhotoService.EncodeCursor`/`DecodeCursor`. (2) **Offset** (`page` + `pageSize`): legacy path, kept for slideshow. `PhotoPageDto.NextCursor` is `null` on offset responses (see ADR 004).
 - **Browse grid virtualizer**: `@tanstack/react-virtual` (`useVirtualizer`) windows rows. Only rows within the visible viewport ± 5-row overscan are in the DOM. Column count is derived from container width via `ResizeObserver` using `columnsForWidth()` in `src/PhotoOrganizer.Web/src/hooks/useInfinitePhotos.ts`. The `react-hooks/incompatible-library` lint warning on `useVirtualizer` is expected — it's a React Compiler note; we don't use the compiler. While scrolling, `PhotoGrid` shows a floating month/year pill (`.scrub-date`) that fades out on idle — computed from `PhotoDto.effectiveDate` (the sort key: `CapturedAt ?? FileModifiedAt`, exposed by the backend).
-- **Live index updates**: `BrowsePage` polls `GET /api/index/status` every 4 s; when the photo count grows it calls `getPhotos` with no cursor to fetch the newest arrivals and prepends them via `useInfinitePhotos.mergeNewest()`. Polling stops when `complete: true`.
+- **Live index updates**: `BrowsePage` polls `GET /api/index/status` every 4 s; when the photo count grows it calls `getPhotos` with no cursor to fetch the newest arrivals and prepends them via `useInfinitePhotos.mergeNewest()`. Polling stops when `complete: true` (see ADR 003 for the progressive indexer and the warm-cache reversal).
 - **Browse filters**: `/api/photos` accepts `folder`, `type`, `deduplicated`, `fileName` (case-insensitive substring on the filename including extension), `dateFrom`/`dateTo` (inclusive day-granularity bounds on effective date = `CapturedAt ?? FileModifiedAt`, compared in UTC). All filters are optional and applied in-memory by `PhotoService.ApplyFilters` before sort/pagination, so they compose safely with the keyset cursor. The frontend (`BrowsePage.tsx`) reads/writes filter state via `useSearchParams` (react-router-dom v7) so filters are URL-encoded, deep-linkable, and survive refresh. Filename is debounced 300 ms before hitting the URL/API. `InfinitePhotosFilters.filterKey` must include every filter field or re-fetch won't trigger on change.
 - **Deferred (issue 39 follow-ups)**: tags filter (waiting for the crawler to write tags into `.meta.json` sidecars — the field is already read and mapped end-to-end, only the filter UI is missing).
-- **Crawler**: .NET 10 Console App (see ADR 001); key packages: `System.CommandLine`, `MetadataExtractor`, `Microsoft.Data.Sqlite`
-  - **Python sub-tool strategy**: Image-heavy steps as standalone Python CLIs under `tools/`, invoked via `Process.Start()` — share sidecar files and SQLite DB, no special IPC
+- **Crawler**: .NET 10 Console App (see ADR 001); key packages: `System.CommandLine`, `MetadataExtractor`, `Microsoft.Data.Sqlite`; pipeline/step framework with tiered change detection (see ADR 009).
+  - **Python sub-tool strategy**: Image-heavy steps as standalone Python CLIs under `tools/`, invoked via `Process.Start()` — share sidecar files and SQLite DB, no special IPC (see ADR 001).
   - **Folder discovery**: `ScanRoots` are searched recursively for `_folder.json` files; each such folder becomes an independent crawl unit (`CrawlTargetResolver`). Photos belong to the nearest ancestor unit; photos not under any unit are skipped. Mirrors `FileSystemFolderRepository` on the server side.
-  - **Process launch**: crawler is started via `ProcessStartInfo.ArgumentList` (not `Arguments`) so embedded spaces or flags in user-supplied fields cannot re-tokenize into extra CLI arguments.
-- **Security — `POST /api/crawler/start`**: requires the `X-Requested-With` header (CSRF guard; forces CORS preflight, blocking disallowed origins); `Mode`/`Step` are validated against the allowlist in `StartCrawlValidation` (`src/PhotoOrganizer.Application/Crawler/StartCrawlValidation.cs`) — valid modes: `full`, `incremental`, `targeted`; valid steps: `metadata`, `duplicates`. Returns 403 if header absent, 400 if mode/step invalid.
-- **Security — bind address**: server binds loopback-only by default (dev: `localhost:6192` via `launchSettings.json`; published: Kestrel default `localhost:5000`). Do not bind to `0.0.0.0` without auth + rate limiting; see SPEC.md §10.
+  - **Process launch**: crawler is started via `ProcessStartInfo.ArgumentList` (not `Arguments`) so user-supplied fields cannot re-tokenize into extra CLI arguments (see ADR 005).
+- **Security — `POST /api/crawler/start`**: requires the `X-Requested-With` header (CSRF guard); `Mode`/`Step` validated against `StartCrawlValidation` (`src/PhotoOrganizer.Application/Crawler/StartCrawlValidation.cs`) — valid modes: `full`, `incremental`, `targeted`; valid steps: `metadata`, `duplicates`. Returns 403 if header absent, 400 if invalid (see ADR 005).
+- **Security — bind address**: server binds loopback-only by default (dev: `localhost:6192` via `launchSettings.json`; published: Kestrel default `localhost:5000`). Do not bind to `0.0.0.0` without auth + rate limiting (see ADR 005).
 
 ## Patterns to Follow
 
-- **Repository pattern** for all data access — domain defines interfaces, infrastructure implements them
-- **Pluggable providers** — camera/storage/detection strategies behind interfaces, easy to swap
-- **Sidecar files** (`_folder.json`, `<name>.<ext>.meta.json`) for all metadata — no database required. Photo sidecars keep the full filename including extension so RAW+JPEG pairs in the same folder each get a distinct sidecar file.
-- **Lazy loading** — index and cache photo metadata on demand rather than at startup
+- **Repository pattern** for all data access — domain defines interfaces, infrastructure implements them (see ADR 008)
+- **Pluggable providers** — camera/storage/detection strategies behind interfaces, easy to swap (see ADR 008)
+- **Sidecar files** (`_folder.json`, `<name>.<ext>.meta.json`) for all metadata — no database required; photo sidecars use the full filename including extension so RAW+JPEG pairs in the same folder each get a distinct sidecar (see ADR 002)
+- **Lazy loading** — index photo metadata progressively in a background service rather than blocking at startup (see ADR 003)
 - **Thread-safe file access** — use semaphore locks when reading/writing shared state
 - **Centralized package versions** — `Directory.Packages.props`; no version numbers inside individual `.csproj` files
 
@@ -141,9 +141,19 @@ HEIC fixture lives in `tests/fixtures/heic/` (separate so it doesn't disturb the
 
 To regenerate JPEG fixtures: `dotnet run --project tools/PhotoOrganizer.FixtureGenerator`. The generator (`tools/PhotoOrganizer.FixtureGenerator/`) uses SixLabors.ImageSharp 3.x (Apache licensed) to write 64×64 JPEGs with EXIF data.
 
+## Architecture Decision Records (ADRs)
+
+ADRs live in `docs/adr/NNN-kebab-title.md`. The format mirrors `docs/adr/001-crawler-stack.md`: `## Status`, `## Context`, `## Decision`, `## Consequences`. Next available number after this issue: **010**.
+
+**During issue planning**, assess whether the work introduces or reverses an architectural decision — a cross-cutting pattern, a tech/library choice, a security-posture change, a data-contract change, or a consciously-accepted tradeoff (including deliberate deferrals and reversals). If so, propose an ADR as part of the plan.
+
+**Always ask the user before creating or materially changing an ADR.** Never write an ADR without explicit confirmation.
+
+**Single source of truth**: rationale, alternatives considered, and accepted tradeoffs belong in the ADR. CLAUDE.md and SPEC.md reference the ADR (`see ADR NNN`) rather than re-explaining it.
+
 ## Documentation Updates
 
-When closing issues via PR, update as needed: **SPEC.md** (requirements/behavior), **README.md** (setup/config), **CLAUDE.md** (implementation details/build/known issues).
+When closing issues via PR, update as needed: **SPEC.md** (requirements/behavior), **README.md** (setup/config), **CLAUDE.md** (implementation details/build/known issues), **docs/adr/** (if the change introduces or reverses an architectural decision — always ask first).
 
 ## Coding Style
 

--- a/docs/adr/002-sidecar-metadata-model.md
+++ b/docs/adr/002-sidecar-metadata-model.md
@@ -1,0 +1,49 @@
+# ADR 002: Sidecar JSON Files as the Metadata Source of Truth
+
+## Status
+
+Accepted
+
+## Context
+
+The photo organizer needs to store per-photo metadata (capture time, duplicate group, preferred flag, crawl step history, tags) and per-folder metadata (label, type, enabled flag). Several storage models were considered:
+
+| Approach | Portability | Failure modes |
+|----------|-------------|---------------|
+| Central relational DB (SQLite/Postgres) | Poor — single file tightly coupled to the installation | DB corruption, path breakage on NAS remap; all metadata lost if DB is deleted |
+| Central SQLite alongside the server | Moderate — one file to back up | Harder to move or split photo libraries; crawler and server would share a write-sensitive file |
+| Sidecar JSON files co-located with photos | Excellent — travels with the photo library | Individual file corruption is isolated; no single point of failure |
+| Embedded index (e.g., one `.catalog.json` per root) | Moderate | Still decoupled from individual files; large files hard to merge |
+
+The photos live on a Synology NAS accessed over SMB. NAS remaps, partial moves, and folder reorganisations are expected operational events. Metadata must survive any of these without manual recovery.
+
+Additionally, the project has two independent processes: the **crawler** (runs on demand, writes metadata) and the **server** (always-on, reads metadata). Sharing a write-sensitive database between them would require connection multiplexing and careful serialization; a sidecar-per-file model requires no coordination at all.
+
+## Decision
+
+**All photo and folder metadata lives in co-located JSON sidecar files.**
+
+- **Folder-level**: `_folder.json` in each source folder root (`schemas/folder.schema.json`)
+- **Photo-level**: `<name>.<ext>.meta.json` beside each photo file — the full filename including extension is used so `IMG_1234.orf` and `IMG_1234.jpg` each get a distinct sidecar (`schemas/photo-meta.schema.json`)
+
+The **crawler's SQLite DB** (`crawl_log`) holds only operational state — hashes, mod-times, step-run records — used for incremental crawl efficiency. It is never the source of truth for photo metadata, and the server accesses it read-only. Deleting it forces a full recrawl but loses no metadata.
+
+The **crawler↔server integration contract** is: filesystem + exit codes. No IPC, no shared library, no network protocol.
+
+**Schema evolution rule**: new optional fields may be added freely; existing fields must not be removed or renamed; readers must tolerate unknown fields (`JsonSerializer` with `PropertyNameCaseInsensitive = true` and no `JsonExtensionData` rejection). Version compatibility tests live in `tests/PhotoOrganizer.Application.Tests/SidecarsTests.cs`.
+
+**Atomic writes**: sidecars are written via temp-file-then-rename (`File.Move(..., overwrite: true)`) so an interrupted write never produces a partial or zero-byte file. See also `src/PhotoOrganizer.Crawler/Sidecars/JsonSidecarStore.cs`.
+
+## Consequences
+
+**Positive:**
+- Photo metadata is portable — moving the library to a different NAS or path requires no migration
+- Corruption is isolated to a single file; the rest of the library is unaffected
+- The crawler and server require no shared database or connection pool
+- Metadata is human-readable and inspectable with any text editor
+- A photo can be deleted, and its sidecar naturally disappears with it
+
+**Accepted tradeoffs:**
+- Querying across the full library (filtering, sorting) requires an in-memory index built at server startup (see ADR 003); no ad-hoc SQL is possible
+- Writing a sidecar during an ongoing crawl requires file locking to prevent torn writes
+- Schema changes require a migration strategy for existing sidecar files in the field

--- a/docs/adr/003-in-memory-index.md
+++ b/docs/adr/003-in-memory-index.md
@@ -1,0 +1,55 @@
+# ADR 003: Progressive Randomized In-Memory Index (and the Warm-Cache Reversal)
+
+## Status
+
+Accepted
+
+## Context
+
+The server needs to enumerate the full photo library for browse-grid and slideshow requests. Photos live on a Synology NAS over SMB. A synchronous filesystem walk at startup was measured at ~56 seconds for a medium-sized library — unacceptable for server cold-start time.
+
+Three indexing strategies were considered:
+
+| Strategy | Cold-start | Browse availability | Freshness |
+|----------|-----------|---------------------|-----------|
+| Blocking walk at startup | Long (56 s measured) | Only after full walk | Always current |
+| Query filesystem per request | No startup delay | Immediate | Always current, but per-request cost high on SMB |
+| Progressive background index | Near-zero startup | Immediately (grows as indexing runs) | Rebuilt from sidecars each startup |
+
+A fourth variant — a **persistent warm cache** — was also evaluated. After a full index build, the cache would serialize the index to disk so subsequent restarts could load it instantly instead of re-walking the filesystem.
+
+### The warm-cache reversal
+
+The warm cache was implemented in commit `2cfb5cd` (`RandomizedSidecarIndexer` + `PhotoIndexCache`). In practice it introduced two problems:
+
+1. **Staleness**: the cache did not know about photos added or deleted between restarts, producing phantom or missing entries until the next full recrawl.
+2. **Footgun**: `PhotoIndex.Clear()` / `InvalidateCacheAsync` was called in several places to force a fresh read, but callers could not reliably trigger a full re-index; races produced a permanently empty or partial index after manual invalidation.
+
+Both issues were resolved by removing the warm cache entirely (commit `d5d57f5`) and then removing `InvalidateCacheAsync`/`PhotoIndex.Clear()` (commit `09aadff`): the index is always rebuilt from sidecars at startup. The SMB walk penalty is acceptable because the progressive design means the server is usable within seconds even while indexing is ongoing.
+
+## Decision
+
+**The server builds a thread-safe in-memory index progressively at startup via a `BackgroundService`, always starting from scratch.**
+
+Key properties of `RandomizedSidecarIndexer` (`src/PhotoOrganizer.Infrastructure/Indexing/RandomizedSidecarIndexer.cs`):
+
+- **Lazy / progressive**: photo entries appear in `PhotoIndex` as each sidecar is read; API requests return whatever is indexed so far without waiting.
+- **Randomized**: directories are enqueued and dequeued in random order (Fisher-Yates shuffle + random insertion into the pending list). This ensures a representative cross-section of the library is indexed first rather than one folder dominating the early index.
+- **Parallel workers**: `PhotoOrganizerSettings.Indexing.MaxParallelism` parallel workers drain a shared pending queue, balancing SMB round-trip latency with CPU usage.
+- **Completion signal**: `PhotoIndex.MarkComplete()` / `PhotoIndex.IsComplete` lets the browse page stop polling `GET /api/index/status` once the full index is available.
+- **No caching**: there is no on-disk cache; restarting the server always rebuilds from sidecars. **Do not add `PhotoIndex.Clear()`, `InvalidateCacheAsync`, or a warm-cache path** — these patterns were tried and removed because their staleness and race conditions outweighed the startup-time benefit.
+
+`PhotoIndex` (`src/PhotoOrganizer.Infrastructure/Indexing/PhotoIndex.cs`) is backed by `ConcurrentDictionary<Guid, Photo>` and `ConcurrentDictionary<string, SourceFolder>`. Readers take a point-in-time snapshot (`SnapshotPhotos()`) that does not block indexer workers.
+
+## Consequences
+
+**Positive:**
+- Server is usable within seconds of startup regardless of library size
+- Each startup surfaces a randomized spread of photos, so the grid feels populated quickly even for multi-thousand-photo libraries
+- Eliminating the warm cache removes an entire class of staleness bugs and the `Clear()`/`InvalidateCacheAsync` footgun
+- Simple mental model: "the index is whatever sidecars currently exist on disk"
+
+**Accepted tradeoffs:**
+- Every server restart re-reads all sidecars from the NAS; on large libraries this takes minutes for full indexing (but browse is available throughout)
+- There is no way to add a photo to the index without a crawler run or a server restart (the index is read-only at runtime)
+- The live-update polling (`BrowsePage` polls `GET /api/index/status` every 4 s) is only relevant during the initial indexing window, not for photo additions after the index is complete

--- a/docs/adr/004-keyset-cursor-pagination.md
+++ b/docs/adr/004-keyset-cursor-pagination.md
@@ -1,0 +1,48 @@
+# ADR 004: Keyset Cursor Pagination for the Browse Grid
+
+## Status
+
+Accepted
+
+## Context
+
+The browse grid needs to load photos in pages as the user scrolls. The in-memory index is append-only during a startup index build: new photos are prepended (newest-first sort) as the background indexer runs. Two standard pagination strategies were evaluated:
+
+| Strategy | Stability under concurrent prepends | Implementation complexity |
+|----------|-------------------------------------|---------------------------|
+| Offset (`SKIP n TAKE m`) | Poor — offset shifts when items are prepended; the same photo can appear on two consecutive pages or a photo can be skipped entirely | Simple |
+| Keyset cursor | Stable — cursor points to a specific item; the next page starts immediately after it regardless of prepends | Moderate |
+
+Offset pagination was kept for the **slideshow** endpoint (`/api/photos?page=N&pageSize=M`), which is a single-pass, single-user flow where prepend instability is acceptable and the simpler API is preferable.
+
+## Decision
+
+**`GET /api/photos` supports two pagination modes; the browse grid uses keyset cursor pagination.**
+
+### Keyset path (`cursor` + `limit` params)
+
+- Sort order: `CapturedAt ?? FileModifiedAt` descending, `Id` descending as a tiebreaker (the `Id` tiebreaker guarantees cursor determinism when two photos share the same effective timestamp).
+- Cursor format: `base64url("{effectiveTimestampUtcTicks}_{idN}")` — human-readable in logs, URL-safe, no padding.
+- Implementation: `PhotoService.EncodeCursor` / `DecodeCursor` / `EffectiveTicks` in `src/PhotoOrganizer.Infrastructure/Services/PhotoService.cs`.
+- `PhotoPageDto.NextCursor` is `null` on the last page (fewer results than `limit`), signalling to the frontend that infinite scroll should stop.
+
+### Offset path (`page` + `pageSize` params — legacy)
+
+- Used by the slideshow endpoint and retained for future callers.
+- `PhotoPageDto.NextCursor` is `null` on all offset responses.
+
+### Frontend integration
+
+The `useInfinitePhotos` hook (`src/PhotoOrganizer.Web/src/hooks/useInfinitePhotos.ts`) drives the grid: it appends pages using the `NextCursor` value from each response and calls `mergeNewest()` to prepend new arrivals detected by the index-status poll without resetting the scroll position.
+
+## Consequences
+
+**Positive:**
+- Infinite scroll is stable: no photo appears twice or disappears when the index grows during a session
+- The cursor is stateless — no server-side session required; the cursor can be bookmarked or passed between clients
+- The `Id` tiebreaker guarantees deterministic pages even for libraries where many photos share the same capture-time resolution (e.g. burst shots)
+
+**Accepted tradeoffs:**
+- Keyset pagination cannot jump to an arbitrary page number (e.g. "go to page 50") — only forward-sequential traversal is supported
+- Cursor encoding/decoding adds a thin abstraction layer; malformed cursors are silently treated as "start of list" rather than an error
+- Filters compose with the cursor but the cursor is not filter-aware: changing filters while mid-scroll invalidates the current cursor position (the frontend resets the cursor on filter change)

--- a/docs/adr/005-security-posture.md
+++ b/docs/adr/005-security-posture.md
@@ -1,0 +1,58 @@
+# ADR 005: Security Posture — Loopback Bind, No Auth, and Crawler-Start Hardening
+
+## Status
+
+Accepted
+
+## Context
+
+Photo Organizer is a personal, single-user application intended to run on a local machine and serve a browser on the same host. This shapes the threat model materially:
+
+- **Multi-user auth is a non-goal**: there is only one user; adding auth would add complexity with no benefit (SPEC.md §12).
+- **LAN access is explicitly out of scope** until auth and rate limiting are in place (SPEC.md §10).
+- The only state-changing operation exposed over HTTP is `POST /api/crawler/start`. All other endpoints are read-only.
+
+Even in a loopback-only deployment, cross-site request forgery is a real threat: a malicious web page open in the same browser could make a credentialed same-origin-exempt request to `localhost:6192` and trigger a crawler run against an attacker-supplied path. The `POST /api/crawler/start` endpoint also constructs a CLI invocation, making argument injection a concern.
+
+## Decision
+
+**The server binds loopback-only by default; `POST /api/crawler/start` applies layered defense-in-depth.**
+
+### Bind address
+
+- **Development**: `localhost:6192` via `src/PhotoOrganizer.Server/Properties/launchSettings.json`.
+- **Published builds**: Kestrel defaults to `localhost:5000`.
+- Binding to `0.0.0.0` or any non-loopback address is prohibited until authentication and rate limiting are implemented (see `SECURITY.md`).
+
+### CSRF guard — `X-Requested-With` header
+
+`POST /api/crawler/start` requires the `X-Requested-With` header. This header is **not** a CORS-safelisted header, so any cross-origin request that includes it triggers a CORS preflight. The server's CORS policy (configured in `src/PhotoOrganizer.Server/Program.cs`) only allows the known frontend origins; the preflight is blocked for any other origin. The server returns **403** if the header is absent. This approach was chosen over framework anti-forgery tokens because:
+- It requires no session state or cookie
+- It is simpler to implement and test
+- It is sufficient for a loopback-only personal app; token-based CSRF protection is reserved for multi-user deployments
+
+### Allowlist validation — `StartCrawlValidation`
+
+`Mode` and `Step` values are validated against `StartCrawlValidation` (`src/PhotoOrganizer.Application/Crawler/StartCrawlValidation.cs`) before the crawler is launched:
+- Valid modes: `full`, `incremental`, `targeted`
+- Valid steps: `metadata`, `duplicates`
+- Returns **400** with a descriptive message if either field is invalid
+
+`StartCrawlValidation` lives in the Application layer (not Server) so the Server can reference it without taking a dependency on the Crawler project.
+
+### Argument injection prevention — `ProcessStartInfo.ArgumentList`
+
+The crawler is launched via `ProcessStartInfo.ArgumentList` (one token per entry), **never** via `ProcessStartInfo.Arguments` (a single concatenated string). This ensures that user-supplied field values — including mode and step strings — cannot be re-tokenized by the shell into additional flags or arguments even if an invalid value somehow bypasses the allowlist.
+
+## Consequences
+
+**Positive:**
+- Simple, auditable security model: one mutating endpoint, three independent controls
+- No session state or cookies required for CSRF protection
+- Argument injection is structurally impossible regardless of input content
+- Threat surface is minimal — loopback bind prevents LAN/internet exposure entirely
+
+**Accepted tradeoffs:**
+- Binding to non-loopback addresses for legitimate remote access (e.g. same-LAN tablet) requires adding authentication and rate limiting first — this is a deliberate forcing function, not a gap
+- The `X-Requested-With` CSRF guard relies on browsers respecting CORS preflight rules; it would not protect against a same-origin attacker (not a concern for a loopback app)
+- Auth and multi-user support are declared non-goals for this phase; revisiting them would require significant new infrastructure

--- a/docs/adr/006-heic-transcoding.md
+++ b/docs/adr/006-heic-transcoding.md
@@ -1,0 +1,52 @@
+# ADR 006: On-the-Fly HEIC/HEIF Transcoding via Magick.NET (No Caching)
+
+## Status
+
+Accepted
+
+## Context
+
+Modern iPhones and many cameras capture images in HEIC/HEIF format. Only Safari natively supports HEIC in an `<img>` element; Chrome, Firefox, and Edge do not. To serve HEIC photos to all browsers, the server must convert them to JPEG.
+
+ADR 001 noted that Tier 3 perceptual hashing would require a native image-decoding dependency and deferred that decision. HEIC browser support forces the issue earlier: the `/api/photos/{id}/image` endpoint must serve a displayable format for every photo in the library.
+
+Four strategies were considered:
+
+| Strategy | Complexity | Serving latency | Disk usage | Dependencies |
+|----------|-----------|-----------------|------------|--------------|
+| Pre-generate JPEG derivatives at crawl time | High — crawler must write JPEGs, server must discover them | Low (file read) | High — doubles storage for HEIC photos | No new dependency |
+| On-demand transcoding with disk cache | Moderate — cache invalidation, storage quota | Low after first request | Moderate | Native image lib |
+| On-demand transcoding with memory cache | Moderate — eviction policy, memory ceiling | Low after first request | None (memory) | Native image lib |
+| On-demand transcoding, no cache | Low — stateless endpoint | Per-request CPU hit | None | Native image lib |
+
+For a personal single-user app with a small concurrent request rate, per-request transcoding is acceptable. Caching adds complexity (invalidation, storage limits, first-load discrepancy) that is not worth the benefit at this scale. The "no caching" approach is explicitly a v1 tradeoff; a disk-based or memory-based cache can be added later without changing the public API.
+
+Magick.NET (`Magick.NET-Q8-AnyCPU`) was chosen because:
+- It wraps ImageMagick, which includes libheif support
+- It is a well-maintained NuGet package with reliable cross-platform binaries
+- The `IImageTranscoder` abstraction makes it straightforward to swap in another implementation later
+
+## Decision
+
+**HEIC/HEIF photos are transcoded to JPEG on the fly at `/api/photos/{id}/image`, using `Magick.NET-Q8-AnyCPU`. No transcoded result is cached.**
+
+Implementation:
+- `IImageTranscoder` (`src/PhotoOrganizer.Domain/Interfaces/IImageTranscoder.cs`) — abstraction in Domain; injected into the image endpoint
+- `MagickImageTranscoder` (`src/PhotoOrganizer.Infrastructure/Imaging/MagickImageTranscoder.cs`) — concrete implementation; wraps `MagickImage` in `Task.Run` to avoid blocking the request thread
+- `DisplayableImageFormats.IsTranscodable(filePath)` gates which files are transcoded (currently `.heic`, `.heif`)
+
+RAW formats are not transcoded — they are excluded from grid/slideshow listings (see ADR 007) but remain downloadable as `application/octet-stream` via the version panel's image endpoint.
+
+Caching is deferred to a future pass. When added, it should be implemented in the image endpoint or a caching decorator around `IImageTranscoder`, without changing `MagickImageTranscoder`.
+
+## Consequences
+
+**Positive:**
+- All HEIC photos display correctly in every major browser
+- Stateless endpoint — no cache warm-up, no invalidation, no storage budget to manage
+- `IImageTranscoder` abstraction allows swapping the implementation without touching the API layer
+
+**Accepted tradeoffs:**
+- Every HEIC request transcodes from scratch; repeated views of the same photo incur full CPU cost each time
+- `Magick.NET-Q8-AnyCPU` ships a substantial native payload (libheif, ImageMagick) — adds ~50 MB to published builds
+- Transcoding is synchronous at the ImageMagick layer (`Task.Run` provides thread-pool isolation but does not make it truly async I/O)

--- a/docs/adr/007-format-single-source-of-truth.md
+++ b/docs/adr/007-format-single-source-of-truth.md
@@ -1,0 +1,57 @@
+# ADR 007: Format Capability Single-Source-of-Truth and Display Policy
+
+## Status
+
+Accepted
+
+## Context
+
+The photo organizer handles a heterogeneous mix of file formats: JPEG, PNG, WEBP, AVIF, BMP (browser-native), HEIC/HEIF (server-transcoded), and RAW formats (CR2, CR3, ORF, ARW, NEF, RW2) plus TIFF. Multiple subsystems need to know which formats fall into which capability bucket:
+
+- The **indexer** (`RandomizedSidecarIndexer`) must know which files to index at all
+- The **crawler** (`FileDiscoverer`) must know which files to discover
+- The **photo service** (`PhotoService.ApplyFilters`) must know which photos to include in grid and slideshow listings
+- The **transcoder** (`MagickImageTranscoder`) must know which files it can transcode
+- The **duplicate detector** (`DuplicatesStep`) must know which formats are display-preferred
+
+Before the refactors in commits `835fa37`, `afebbde`, and `9cf61db`, these extension sets were duplicated as independent `HashSet<string>` literals scattered across the above components. Adding or removing a format required a multi-file search; omitting one component caused silent errors (e.g. a file indexed but not served, or served but not discoverable).
+
+## Decision
+
+**Two Domain helpers are the single sources of truth for format capabilities. No other code should define its own extension lists.**
+
+### `DisplayableImageFormats` (`src/PhotoOrganizer.Domain/DisplayableImageFormats.cs`)
+
+Defines which formats the server can serve to a browser:
+- `BrowserDisplayableExtensions` — rendered natively by browsers (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.avif`, `.bmp`)
+- `TranscodableExtensions` — transcoded to JPEG by the server before delivery (`.heic`, `.heif`)
+- `AllDisplayableExtensions` — the union of both; used as the baseline for `SupportedPhotoExtensions`
+- `IsDisplayable(filePath)` — used by `PhotoService.ApplyFilters` to gate grid/slideshow listings
+
+### `SupportedPhotoExtensions` (`src/PhotoOrganizer.Domain/SupportedPhotoExtensions.cs`)
+
+Defines which files are recognised as photos at all (indexer + crawler):
+- Constructed as `DisplayableImageFormats.AllDisplayableExtensions ∪ {RAW/TIFF extensions}`
+- Guarantees that every displayable/transcodable format is also discoverable — you can never have a photo served to the grid that the crawler does not know about
+
+**The invariant `displayable ⊆ discoverable` is pinned by a unit test** in `tests/PhotoOrganizer.Application.Tests/SupportedPhotoExtensionsTests.cs` so the two lists cannot silently diverge.
+
+### Display policy
+
+RAW formats (CR2, CR3, ORF, ARW, NEF, RW2) and bare TIFF are:
+- **Discoverable** — the crawler indexes them and they appear in the photo model
+- **Not displayable** — excluded from grid and slideshow listings by `PhotoService.ApplyFilters`
+- **Downloadable** — accessible via the version panel's `/api/photos/{id}/image` endpoint as `application/octet-stream`
+
+This policy means a photographer who shoots RAW+JPEG sees their JPEG in the grid with the RAW available for download in the version panel; a RAW-only photographer can still download files but will not see them in browse or slideshow.
+
+## Consequences
+
+**Positive:**
+- Adding a new format (e.g. AVIF transcoding) requires editing exactly one place
+- The subset invariant test prevents the common error of adding a displayable format without making it discoverable
+- `DuplicatesStep` can rank formats by display preference by delegating to `IsDisplayable` rather than maintaining its own ranking table
+
+**Accepted tradeoffs:**
+- RAW-only users get a degraded grid experience (no thumbnails); this is a known limitation pending Tier 3 transcoding support (see ADR 001)
+- Bare TIFF is excluded from display even though some TIFFs are browser-renderable — conservative choice to avoid browser compatibility edge cases

--- a/docs/adr/008-clean-architecture.md
+++ b/docs/adr/008-clean-architecture.md
@@ -1,0 +1,59 @@
+# ADR 008: Clean Architecture Layering and Repository Pattern
+
+## Status
+
+Accepted
+
+## Context
+
+The backend needs a structure that keeps business logic testable and independent of I/O concerns (filesystem, sidecar format, ASP.NET). Several approaches were considered:
+
+| Approach | Testability | Change isolation | Complexity |
+|----------|------------|-----------------|------------|
+| Monolithic ASP.NET service layer | Poor — domain logic tightly coupled to HTTP/DI | Any infrastructure change touches business logic | Low |
+| Transaction-script style | Moderate — logic can be extracted, but coupling is implicit | Difficult to swap implementations | Low–moderate |
+| Clean Architecture (Domain → Application → Infrastructure → Server) | High — domain is pure .NET; infrastructure is fully swappable | Each layer has a well-defined seam | Moderate |
+
+The project targets a personal NAS deployment where storage technology (filesystem/SMB paths, sidecar format, crawler stack) may evolve, but the core domain concepts (photo, folder, duplicate group) are stable. Isolating domain logic from infrastructure is a high-value investment.
+
+The architecture is modeled on the [photo-booth-take-two](https://github.com/magnusakselvoll/photo-booth-take-two) reference implementation.
+
+## Decision
+
+**The backend follows Clean Architecture with a strict dependency direction: Domain → Application → Infrastructure → Server.**
+
+### Layer responsibilities
+
+| Project | Responsibility |
+|---------|---------------|
+| `PhotoOrganizer.Domain` | Entities (`Photo`, `SourceFolder`), value objects, repository interfaces, domain helpers (`DisplayableImageFormats`, `SupportedPhotoExtensions`) — add here first |
+| `PhotoOrganizer.Application` | Use cases, DTOs, service interfaces (`IPhotoService`), validation (`StartCrawlValidation`) — no I/O |
+| `PhotoOrganizer.Infrastructure` | File system access, sidecar parsing, indexing (`RandomizedSidecarIndexer`), image transcoding (`MagickImageTranscoder`), crawler service |
+| `PhotoOrganizer.Server` | ASP.NET Core host, API endpoints, middleware, DI wiring, static file serving |
+| `PhotoOrganizer.Web` | React + TypeScript frontend (Vite build, deployed as static files under `wwwroot/`) |
+
+### Repository pattern
+
+All data access goes through domain-defined interfaces:
+- `IPhotoRepository` — list, find, serve photos
+- `IFolderRepository` — discover and read source folders
+- `ISidecarReader` / `ISidecarStore` — read/write sidecar metadata
+- `IImageTranscoder` — transcode images for browser delivery
+
+Infrastructure implements these interfaces; the Application and Domain layers never reference concrete infrastructure types. This makes unit testing straightforward: tests inject fakes/stubs rather than hitting the filesystem.
+
+### Pluggable providers
+
+Camera-specific logic, storage backends, and detection strategies are implemented behind interfaces so they can be swapped or extended without touching the domain. The crawler's `IBatchProcessingStep` / `IProcessingStep` follow the same pattern (see ADR 009).
+
+## Consequences
+
+**Positive:**
+- Domain and Application layers have zero I/O dependencies; unit tests are fast and require no filesystem setup
+- Infrastructure implementations can be replaced (e.g. swapping `MagickImageTranscoder` for a different transcoding backend) without touching business logic
+- The layering makes it clear where new code belongs: domain concepts go in `Domain`, use cases in `Application`, I/O implementations in `Infrastructure`
+- Consistent with the reference implementation; developers familiar with either codebase can navigate both
+
+**Accepted tradeoffs:**
+- More projects and more indirection than a simple monolith; justified by the expected lifetime and extensibility requirements of the project
+- Interface boundaries require explicit DI wiring in `Program.cs`; adding a new feature requires touching multiple projects

--- a/docs/adr/009-crawler-pipeline.md
+++ b/docs/adr/009-crawler-pipeline.md
@@ -1,0 +1,84 @@
+# ADR 009: Crawler Pipeline/Step Framework and Tiered Change Detection
+
+## Status
+
+Accepted
+
+## Context
+
+The crawler needs to run multiple distinct processing operations on each photo file: at minimum metadata extraction and duplicate detection, and in future phases GPS enrichment, auto-tagging, and perceptual hashing (see ADR 001). These operations differ in:
+
+- **Cost**: metadata extraction is fast (EXIF read); perceptual hashing will be slow (image decode + hash computation)
+- **Frequency**: metadata rarely changes after initial crawl; duplicate detection may need re-running when new photos arrive
+- **Dependencies**: duplicate detection must run after metadata (it uses the captured timestamp from the metadata step)
+
+A monolithic single-pass crawler would re-run all operations on every file every crawl, which becomes prohibitively expensive as the library grows and more processing steps are added.
+
+Additionally, the crawler runs on a NAS where backup tools (Time Machine, rsync) routinely update file modification times without changing content. A naive mtime-based change check would reprocess every file after each backup restore.
+
+## Decision
+
+**The crawler uses a named, versioned step pipeline with per-file step-completion records, and detects changes using a tiered mtime-then-SHA-256 strategy.**
+
+### Pipeline framework
+
+Processing steps implement `IProcessingStep` (`src/PhotoOrganizer.Crawler/Pipeline/IProcessingStep.cs`) or `IBatchProcessingStep`:
+
+```csharp
+public interface IProcessingStep
+{
+    string Name    { get; }   // e.g. "metadata", "duplicates"
+    int Version    { get; }   // increment to force re-run for all files
+    IReadOnlyList<string> DependsOn { get; }
+    Task ExecuteAsync(ProcessingContext context);
+}
+```
+
+`PipelineRunner` (`src/PhotoOrganizer.Crawler/Pipeline/PipelineRunner.cs`) iterates registered steps in dependency order. For each step, it checks `sidecar.CrawlSteps[step.Name].Version`:
+- If `existingVersion >= step.Version` → skip (already processed at this version)
+- Otherwise → execute the step, record `{version, completedAt}` in the sidecar
+
+Steps are registered in `StepRegistry` and `CrawlOrchestrator` runs the pipeline per file.
+
+**Version bump semantics**: incrementing `IProcessingStep.Version` marks all existing per-file records as stale, causing the step to re-run for every file on the next crawl. This is the correct way to force a global re-process (e.g. when the duplicate-detection algorithm changes); it does not require deleting sidecars or a full recrawl flag.
+
+**`crawlSteps` in the sidecar** (`schemas/photo-meta.schema.json`, `SPEC.md §5`):
+```json
+"crawlSteps": {
+  "metadata":   { "version": 1, "completedAt": "2025-03-15T10:00:00Z" },
+  "duplicates": { "version": 1, "completedAt": "2025-03-15T10:00:05Z" }
+}
+```
+
+### Tiered change detection
+
+`ChangeDetector` (`src/PhotoOrganizer.Crawler/ChangeDetection/ChangeDetector.cs`) evaluates each file in two tiers:
+
+| Tier | Check | Result |
+|------|-------|--------|
+| 1 | `|storedMtime − fileMtime| < 1 s` → unchanged | Skip all steps (fast path) |
+| 2 | Compute SHA-256; compare with stored hash | Matching hash → `ModTimeOnly` (update mtime only, skip re-processing); differing hash → `Changed` (run all pending steps) |
+
+`ModTimeOnly` handles the common NAS/backup-restore case where mtime is bumped but content is identical. It updates the stored mtime so tier-1 hits on the next run, avoiding a hash computation every crawl.
+
+### Current steps
+
+| Step | Class | Version | Depends on |
+|------|-------|---------|-----------|
+| `metadata` | `MetadataStep` | 1 | — |
+| `duplicates` | `DuplicatesStep` | 1 | `metadata` |
+
+Future steps (faces, GPS, auto-tag) will follow the same pattern; see ADR 001 for the Python sub-tool strategy for image-heavy steps.
+
+## Consequences
+
+**Positive:**
+- Incremental crawls are cheap: only new or changed files run the full pipeline; unchanged files are skipped in one mtime comparison
+- Version bumps provide a clean, targeted way to force re-processing of a specific step without touching other steps or deleting sidecars
+- New processing steps can be added without modifying `CrawlOrchestrator` — they self-register via `StepRegistry`
+- The `crawlSteps` record in the sidecar makes it possible to audit exactly which steps ran and when for any given photo
+
+**Accepted tradeoffs:**
+- Step version numbers must be incremented manually by the developer; forgetting to bump the version means a changed algorithm will not re-run on existing files
+- The dependency order is currently enforced by `DependsOn` at registration time; circular dependencies would cause undefined behavior (not currently validated at startup)
+- SHA-256 is computed on the full file; for very large RAW files (50+ MB) this adds noticeable I/O cost on the first changed-file detection


### PR DESCRIPTION
## Summary

- Adds 8 backfill ADRs documenting architectural decisions already embedded in the codebase but previously recorded only as dense prose in CLAUDE.md/SPEC.md (or nowhere):
  - **ADR 002** — Sidecar JSON files as the metadata source of truth (no database)
  - **ADR 003** — Progressive randomized in-memory index + warm-cache reversal
  - **ADR 004** — Keyset cursor pagination for the browse grid
  - **ADR 005** — Security posture: loopback bind + CSRF/allowlist/ArgumentList hardening
  - **ADR 006** — On-the-fly HEIC transcoding via Magick.NET, no caching
  - **ADR 007** — Format capability single-source-of-truth and display policy
  - **ADR 008** — Clean Architecture layering + repository pattern
  - **ADR 009** — Crawler pipeline/step framework + tiered change detection
- Trims CLAUDE.md: deep rationale and tradeoff prose replaced by `(see ADR NNN)` pointers, keeping operational facts (file paths, behavior)
- Adds `## Architecture Decision Records` section to CLAUDE.md with the process rules: assess during planning, always ask before creating, rationale lives in the ADR

## Test plan

- [x] `ls docs/adr/` shows 001–009, all with `## Status / ## Context / ## Decision / ## Consequences`
- [x] All `ADR NNN` references in CLAUDE.md resolve to existing files
- [x] `dotnet build` passes (docs-only change)

Closes #73