### PR TITLE
fix: slideshow info overlay — full filenames and toggle/auto-hide (#70, #71)

### DIFF
--- a/src/PhotoOrganizer.Infrastructure/Services/PhotoService.cs
+++ b/src/PhotoOrganizer.Infrastructure/Services/PhotoService.cs
@@ -77,7 +77,7 @@ public sealed class PhotoService(IPhotoRepository repository) : IPhotoService
                 .Select(p => new PhotoVersionDto
                 {
                     Id = p.Id,
-                    FileName = p.FileName,
+                    FileName = Path.GetFileName(p.FilePath),
                     FolderType = p.FolderType.ToString(),
                     FilePath = p.FilePath,
                     IsPreferred = p.IsPreferred,
@@ -158,7 +158,7 @@ public sealed class PhotoService(IPhotoRepository repository) : IPhotoService
     {
         Id = photo.Id,
         FilePath = photo.FilePath,
-        FileName = photo.FileName,
+        FileName = Path.GetFileName(photo.FilePath),
         CapturedAt = photo.CapturedAt,
         EffectiveDate = photo.CapturedAt ?? photo.FileModifiedAt,
         FolderType = photo.FolderType.ToString(),

--- a/src/PhotoOrganizer.Web/src/hooks/useOverlayMessage.ts
+++ b/src/PhotoOrganizer.Web/src/hooks/useOverlayMessage.ts
@@ -6,23 +6,77 @@ const DEFAULT_DURATION_MS = 3_000;
 export interface OverlayMessageState {
   message: ReactNode | null;
   showMessage: (content: ReactNode, durationMs?: number) => void;
+  hide: () => void;
+  toggleMessage: (content: ReactNode, durationMs: number, key: string) => void;
+  hideKey: (key: string) => void;
 }
 
 /**
  * Manages a transient on-screen overlay message that fades out automatically.
  * Suitable for keyboard-shortcut feedback and action confirmations.
+ *
+ * Panels that should toggle (i.e. show / hide with the same key press) should use
+ * `toggleMessage` with a stable string key, then call `hideKey(key)` from any effect
+ * that should dismiss the panel (e.g. when the photo advances). Keyless `showMessage`
+ * calls (toast feedback) are unaffected by the key mechanism.
  */
 export function useOverlayMessage(): OverlayMessageState {
   const [message, setMessage] = useState<ReactNode | null>(null);
   const timerRef = useRef<number | null>(null);
+  // Tracks which keyed panel is currently open; null for keyless toasts.
+  const keyRef = useRef<string | null>(null);
 
-  const showMessage = useCallback((content: ReactNode, durationMs = DEFAULT_DURATION_MS) => {
+  const hide = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    keyRef.current = null;
+    setMessage(null);
+  }, []);
+
+  const showMessage = useCallback((content: ReactNode, durationMs = DEFAULT_DURATION_MS, key: string | null = null) => {
     if (timerRef.current !== null) clearTimeout(timerRef.current);
+    keyRef.current = key;
     setMessage(content);
     timerRef.current = window.setTimeout(() => {
       setMessage(null);
+      keyRef.current = null;
       timerRef.current = null;
     }, durationMs);
+  }, []);
+
+  const toggleMessage = useCallback((content: ReactNode, durationMs: number, key: string) => {
+    if (keyRef.current === key) {
+      // Same panel already open — hide it (toggle off).
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      keyRef.current = null;
+      setMessage(null);
+    } else {
+      // Different panel or nothing open — show the new panel.
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      keyRef.current = key;
+      setMessage(content);
+      timerRef.current = window.setTimeout(() => {
+        setMessage(null);
+        keyRef.current = null;
+        timerRef.current = null;
+      }, durationMs);
+    }
+  }, []);
+
+  const hideKey = useCallback((key: string) => {
+    if (keyRef.current === key) {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      keyRef.current = null;
+      setMessage(null);
+    }
   }, []);
 
   // Clear timer on unmount
@@ -32,5 +86,5 @@ export function useOverlayMessage(): OverlayMessageState {
     };
   }, []);
 
-  return { message, showMessage };
+  return { message, showMessage, hide, toggleMessage, hideKey };
 }

--- a/src/PhotoOrganizer.Web/src/pages/SlideshowPage.tsx
+++ b/src/PhotoOrganizer.Web/src/pages/SlideshowPage.tsx
@@ -47,6 +47,10 @@ export default function SlideshowPage() {
 
   const slideshow = useSlideshow({ intervalMs });
 
+  // Feedback overlay — shown briefly on keyboard actions (and for 10s on info / help).
+  // Declared before the crossfade effect so hideKey can be called when the photo changes.
+  const overlay = useOverlayMessage();
+
   // Crossfade: maintain current + previous display state
   const [currentDisplay, setCurrentDisplay] = useState<DisplayState | null>(null);
   const [previousDisplay, setPreviousDisplay] = useState<DisplayState | null>(null);
@@ -58,6 +62,9 @@ export default function SlideshowPage() {
     if (!photo || photo.id === lastPhotoIdRef.current) return;
 
     lastPhotoIdRef.current = photo.id;
+
+    // Dismiss the info panel when the photo changes — it would otherwise show stale info.
+    overlay.hideKey('info');
 
     setCurrentDisplay(prev => {
       if (prev) {
@@ -71,7 +78,7 @@ export default function SlideshowPage() {
         key: displayKeyRef.current,
       };
     });
-  }, [slideshow.currentPhoto, intervalMs, transitionMs]);
+  }, [slideshow.currentPhoto, intervalMs, transitionMs, overlay]);
 
   // Controls overlay — show on cursor movement, hide after inactivity
   const [controlsVisible, setControlsVisible] = useState(false);
@@ -90,9 +97,6 @@ export default function SlideshowPage() {
       if (hideTimerRef.current !== null) clearTimeout(hideTimerRef.current);
     };
   }, []);
-
-  // Feedback overlay — shown briefly on keyboard actions (and for 10s on info / help)
-  const overlay = useOverlayMessage();
 
   const handleExit = useCallback(() => navigate('/'), [navigate]);
 
@@ -116,23 +120,24 @@ export default function SlideshowPage() {
     overlay.showMessage(`Display time: ${formatDuration(next)}`);
   }, [intervalSeconds, overlay]);
 
-  // Info panel
+  // Info panel — toggles on repeated 'i', hides on photo change (see photo-change effect below)
   const handleShowInfo = useCallback(() => {
     if (!currentDisplay) return;
-    overlay.showMessage(
+    overlay.toggleMessage(
       <PhotoInfoPanel photo={currentDisplay.photo} intervalSeconds={intervalSeconds} />,
       INFO_DURATION_MS,
+      'info',
     );
   }, [currentDisplay, intervalSeconds, overlay]);
 
-  // Index info
+  // Index info — toggles on repeated 'x'
   const handleShowIndex = useCallback(() => {
-    overlay.showMessage(<IndexInfoPanel />, INFO_DURATION_MS);
+    overlay.toggleMessage(<IndexInfoPanel />, INFO_DURATION_MS, 'index');
   }, [overlay]);
 
-  // Shortcut help
+  // Shortcut help — toggles on repeated '?'
   const handleShowHelp = useCallback(() => {
-    overlay.showMessage(<ShortcutHelp />, INFO_DURATION_MS);
+    overlay.toggleMessage(<ShortcutHelp />, INFO_DURATION_MS, 'help');
   }, [overlay]);
 
   useKeyboardNavigation({

--- a/src/PhotoOrganizer.Web/src/test/SlideshowPage.test.tsx
+++ b/src/PhotoOrganizer.Web/src/test/SlideshowPage.test.tsx
@@ -32,6 +32,7 @@ const mockPhoto2 = {
 vi.mock('../api/client', () => ({
   getConfig: vi.fn(),
   getSlideshowNext: vi.fn(),
+  getIndexStats: vi.fn(),
   imageUrl: (id: string) => `/api/photos/${id}/image`,
 }));
 
@@ -68,6 +69,12 @@ beforeEach(() => {
   vi.mocked(client.getConfig).mockResolvedValue({
     scanRoots: [],
     slideshow: { intervalSeconds: 8, transitionMs: 500 },
+  });
+  vi.mocked(client.getIndexStats).mockResolvedValue({
+    complete: true,
+    totalPhotoCount: 42,
+    sidecarSizeBytes: 1024,
+    folders: [],
   });
 });
 
@@ -135,6 +142,87 @@ test('pressing Escape navigates back to browse page', async () => {
   });
 
   expect(screen.getByText('Browse page')).toBeInTheDocument();
+});
+
+test('pressing i shows the info panel; pressing i again hides it (toggle)', async () => {
+  vi.mocked(client.getSlideshowNext).mockResolvedValue(mockPhoto1);
+
+  renderSlideshow();
+  await flushPromises();
+
+  // Info panel not visible yet
+  expect(screen.queryByText('Folder type')).not.toBeInTheDocument();
+
+  // First i press — panel appears
+  await act(async () => { pressKey('i'); });
+  expect(screen.getByText('Folder type')).toBeInTheDocument();
+
+  // Second i press — panel hides
+  await act(async () => { pressKey('i'); });
+  expect(screen.queryByText('Folder type')).not.toBeInTheDocument();
+});
+
+test('info panel hides when the photo advances', async () => {
+  vi.mocked(client.getSlideshowNext)
+    .mockResolvedValueOnce(mockPhoto1)
+    .mockResolvedValueOnce(mockPhoto2)
+    .mockResolvedValue(mockPhoto1);
+
+  renderSlideshow();
+  await flushPromises();
+
+  // Open the info panel while photo1 is showing
+  await act(async () => { pressKey('i'); });
+  expect(screen.getByText('Folder type')).toBeInTheDocument();
+
+  // Advance to photo2 via ArrowRight
+  await act(async () => { pressKey('ArrowRight'); });
+  await flushPromises();
+
+  // Info panel should have been dismissed
+  expect(screen.queryByText('Folder type')).not.toBeInTheDocument();
+});
+
+test('info panel hides when slideshow auto-advances', async () => {
+  vi.mocked(client.getSlideshowNext)
+    .mockResolvedValueOnce(mockPhoto1)
+    .mockResolvedValueOnce(mockPhoto2)
+    .mockResolvedValue(mockPhoto1);
+
+  renderSlideshow();
+  await flushPromises();
+
+  // Open the info panel
+  await act(async () => { pressKey('i'); });
+  expect(screen.getByText('Folder type')).toBeInTheDocument();
+
+  // Auto-advance fires after the 8s configured interval
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(8_000);
+  });
+  await flushPromises();
+
+  // Info panel should be gone (photo changed)
+  expect(screen.queryByText('Folder type')).not.toBeInTheDocument();
+});
+
+test('pressing x shows the index panel; pressing x again hides it (toggle)', async () => {
+  vi.mocked(client.getSlideshowNext).mockResolvedValue(mockPhoto1);
+
+  renderSlideshow();
+  await flushPromises();
+
+  // Index panel not visible yet
+  expect(screen.queryByText(/sidecar size/i)).not.toBeInTheDocument();
+
+  // First x press — panel appears (IndexInfoPanel fetches stats; flush promises)
+  await act(async () => { pressKey('x'); });
+  await flushPromises();
+  expect(screen.getByText(/sidecar size/i)).toBeInTheDocument();
+
+  // Second x press — panel hides
+  await act(async () => { pressKey('x'); });
+  expect(screen.queryByText(/sidecar size/i)).not.toBeInTheDocument();
 });
 
 test('auto-advances after the configured interval using the prefetched photo', async () => {

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceCursorTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceCursorTests.cs
@@ -22,7 +22,7 @@ public sealed class PhotoServiceCursorTests
         Guid? id = null) => new()
     {
         Id = id ?? Guid.NewGuid(),
-        FilePath = $@"C:\photos\{name}.jpg",
+        FilePath = $"/photos/{name}.jpg",
         FileName = name,
         FolderType = FolderType.Originals,
         CapturedAt = capturedAt,
@@ -86,8 +86,8 @@ public sealed class PhotoServiceCursorTests
         var page = await Service(photos).GetPhotosAsync(CursorFilter(limit: 2));
 
         Assert.AreEqual(2, page.Items.Count);
-        Assert.AreEqual("may", page.Items[0].FileName);
-        Assert.AreEqual("mar", page.Items[1].FileName);
+        Assert.AreEqual("may.jpg", page.Items[0].FileName);
+        Assert.AreEqual("mar.jpg", page.Items[1].FileName);
         Assert.IsNotNull(page.NextCursor, "NextCursor should be set when more items remain");
     }
 
@@ -119,19 +119,19 @@ public sealed class PhotoServiceCursorTests
 
         var page1 = await svc.GetPhotosAsync(CursorFilter(limit: 2));
         Assert.AreEqual(2, page1.Items.Count);
-        Assert.AreEqual("p1", page1.Items[0].FileName);
-        Assert.AreEqual("p2", page1.Items[1].FileName);
+        Assert.AreEqual("p1.jpg", page1.Items[0].FileName);
+        Assert.AreEqual("p2.jpg", page1.Items[1].FileName);
         Assert.IsNotNull(page1.NextCursor);
 
         var page2 = await svc.GetPhotosAsync(CursorFilter(limit: 2, cursor: page1.NextCursor));
         Assert.AreEqual(2, page2.Items.Count);
-        Assert.AreEqual("p3", page2.Items[0].FileName);
-        Assert.AreEqual("p4", page2.Items[1].FileName);
+        Assert.AreEqual("p3.jpg", page2.Items[0].FileName);
+        Assert.AreEqual("p4.jpg", page2.Items[1].FileName);
         Assert.IsNotNull(page2.NextCursor);
 
         var page3 = await svc.GetPhotosAsync(CursorFilter(limit: 2, cursor: page2.NextCursor));
         Assert.AreEqual(1, page3.Items.Count);
-        Assert.AreEqual("p5", page3.Items[0].FileName);
+        Assert.AreEqual("p5.jpg", page3.Items[0].FileName);
         Assert.IsNull(page3.NextCursor);
     }
 
@@ -174,8 +174,8 @@ public sealed class PhotoServiceCursorTests
 
         var page = await Service(photos).GetPhotosAsync(CursorFilter(limit: 2));
 
-        Assert.AreEqual("photoB", page.Items[0].FileName);
-        Assert.AreEqual("photoA", page.Items[1].FileName);
+        Assert.AreEqual("photoB.jpg", page.Items[0].FileName);
+        Assert.AreEqual("photoA.jpg", page.Items[1].FileName);
     }
 
     // ─── New photos don't disturb a cursor ───────────────────────────────────
@@ -203,9 +203,9 @@ public sealed class PhotoServiceCursorTests
         var page2 = await svc.GetPhotosAsync(CursorFilter(limit: 2, cursor: page1.NextCursor));
 
         Assert.AreEqual(1, page2.Items.Count);
-        Assert.AreEqual("p3", page2.Items[0].FileName);
+        Assert.AreEqual("p3.jpg", page2.Items[0].FileName);
         // p1 and p2 must NOT re-appear.
-        Assert.IsFalse(page2.Items.Any(x => x.FileName is "p1" or "p2"));
+        Assert.IsFalse(page2.Items.Any(x => x.FileName is "p1.jpg" or "p2.jpg"));
     }
 
     // ─── TotalCount is always the full filtered count ─────────────────────────
@@ -241,7 +241,7 @@ public sealed class PhotoServiceCursorTests
         });
 
         Assert.AreEqual(1, page.Items.Count);
-        Assert.AreEqual("newest", page.Items[0].FileName);
+        Assert.AreEqual("newest.jpg", page.Items[0].FileName);
         Assert.IsNull(page.NextCursor, "Offset path must not set NextCursor");
     }
 

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceDisplayOrderTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceDisplayOrderTests.cs
@@ -19,7 +19,7 @@ public sealed class PhotoServiceDisplayOrderTests
     private static Photo Make(string name, DateTimeOffset? capturedAt, DateTimeOffset? fileModifiedAt = null) => new()
     {
         Id = Guid.NewGuid(),
-        FilePath = $@"C:\photos\{name}.jpg",
+        FilePath = $"/photos/{name}.jpg",
         FileName = name,
         FolderType = FolderType.Originals,
         CapturedAt = capturedAt,
@@ -52,9 +52,9 @@ public sealed class PhotoServiceDisplayOrderTests
 
         var page = await GetAllAsync(photos);
 
-        Assert.AreEqual("newest", page.Items[0].FileName);
-        Assert.AreEqual("middle", page.Items[1].FileName);
-        Assert.AreEqual("oldest", page.Items[2].FileName);
+        Assert.AreEqual("newest.jpg", page.Items[0].FileName);
+        Assert.AreEqual("middle.jpg", page.Items[1].FileName);
+        Assert.AreEqual("oldest.jpg", page.Items[2].FileName);
     }
 
     // ─── FileModifiedAt fallback ──────────────────────────────────────────────
@@ -70,8 +70,8 @@ public sealed class PhotoServiceDisplayOrderTests
 
         var page = await GetAllAsync(photos);
 
-        Assert.AreEqual("new_file", page.Items[0].FileName);
-        Assert.AreEqual("old_file", page.Items[1].FileName);
+        Assert.AreEqual("new_file.jpg", page.Items[0].FileName);
+        Assert.AreEqual("old_file.jpg", page.Items[1].FileName);
     }
 
     [TestMethod]
@@ -87,8 +87,8 @@ public sealed class PhotoServiceDisplayOrderTests
 
         var page = await GetAllAsync(photos);
 
-        Assert.AreEqual("new_capture", page.Items[0].FileName);
-        Assert.AreEqual("old_capture", page.Items[1].FileName);
+        Assert.AreEqual("new_capture.jpg", page.Items[0].FileName);
+        Assert.AreEqual("old_capture.jpg", page.Items[1].FileName);
     }
 
     [TestMethod]
@@ -102,8 +102,8 @@ public sealed class PhotoServiceDisplayOrderTests
 
         var page = await GetAllAsync(photos);
 
-        Assert.AreEqual("has_dates", page.Items[0].FileName);
-        Assert.AreEqual("no_dates",  page.Items[1].FileName);
+        Assert.AreEqual("has_dates.jpg", page.Items[0].FileName);
+        Assert.AreEqual("no_dates.jpg",  page.Items[1].FileName);
     }
 
     // ─── Empty list ───────────────────────────────────────────────────────────

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceDisplayableFilterTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceDisplayableFilterTests.cs
@@ -18,7 +18,7 @@ public sealed class PhotoServiceDisplayableFilterTests
     private static Photo Make(string name, string extension, bool isPreferred = false, Guid? duplicateGroupId = null) => new()
     {
         Id = Guid.NewGuid(),
-        FilePath = $@"C:\photos\{name}{extension}",
+        FilePath = $"/photos/{name}{extension}",
         FileName = $"{name}{extension}",
         FolderType = FolderType.Originals,
         CapturedAt = AnyDate,

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceFilterTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceFilterTests.cs
@@ -61,7 +61,7 @@ public sealed class PhotoServiceFilterTests
         });
 
         Assert.AreEqual(1, page.TotalCount);
-        Assert.AreEqual("IMG_1001", page.Items[0].FileName);
+        Assert.AreEqual("IMG_1001.jpg", page.Items[0].FileName);
     }
 
     [TestMethod]
@@ -82,7 +82,7 @@ public sealed class PhotoServiceFilterTests
         });
 
         Assert.AreEqual(1, page.TotalCount);
-        Assert.AreEqual("photo", page.Items[0].FileName);
+        Assert.AreEqual("photo.png", page.Items[0].FileName);
         Assert.IsTrue(page.Items[0].FilePath.EndsWith(".png", StringComparison.OrdinalIgnoreCase));
     }
 
@@ -187,9 +187,9 @@ public sealed class PhotoServiceFilterTests
 
         Assert.AreEqual(2, page.TotalCount);
         var names = page.Items.Select(p => p.FileName).ToList();
-        CollectionAssert.Contains(names, "jan");
-        CollectionAssert.Contains(names, "jun");
-        CollectionAssert.DoesNotContain(names, "dec");
+        CollectionAssert.Contains(names, "jan.jpg");
+        CollectionAssert.Contains(names, "jun.jpg");
+        CollectionAssert.DoesNotContain(names, "dec.jpg");
     }
 
     // ─── Date range — both bounds ─────────────────────────────────────────────
@@ -213,7 +213,7 @@ public sealed class PhotoServiceFilterTests
         });
 
         Assert.AreEqual(1, page.TotalCount);
-        Assert.AreEqual("jun", page.Items[0].FileName);
+        Assert.AreEqual("jun.jpg", page.Items[0].FileName);
     }
 
     [TestMethod]
@@ -235,7 +235,7 @@ public sealed class PhotoServiceFilterTests
         });
 
         Assert.AreEqual(1, page.TotalCount);
-        Assert.AreEqual("jun", page.Items[0].FileName);
+        Assert.AreEqual("jun.jpg", page.Items[0].FileName);
     }
 
     [TestMethod]
@@ -277,7 +277,7 @@ public sealed class PhotoServiceFilterTests
         });
 
         Assert.AreEqual(1, page.TotalCount);
-        Assert.AreEqual("dated", page.Items[0].FileName);
+        Assert.AreEqual("dated.jpg", page.Items[0].FileName);
     }
 
     [TestMethod]
@@ -297,7 +297,7 @@ public sealed class PhotoServiceFilterTests
         });
 
         Assert.AreEqual(1, page.TotalCount);
-        Assert.AreEqual("dated", page.Items[0].FileName);
+        Assert.AreEqual("dated.jpg", page.Items[0].FileName);
     }
 
     [TestMethod]
@@ -339,7 +339,7 @@ public sealed class PhotoServiceFilterTests
         });
 
         Assert.AreEqual(1, page.TotalCount);
-        Assert.AreEqual("IMG_1002", page.Items[0].FileName);
+        Assert.AreEqual("IMG_1002.jpg", page.Items[0].FileName);
     }
 
     // ─── Cursor stability with new filters ───────────────────────────────────

--- a/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceVersionsTests.cs
+++ b/tests/PhotoOrganizer.Infrastructure.Tests/PhotoServiceVersionsTests.cs
@@ -86,6 +86,43 @@ public sealed class PhotoServiceVersionsTests
         Assert.IsTrue(folderTypes.Contains("Originals"));
     }
 
+    /// <summary>
+    /// Verifies that the DTO derives the display filename from FilePath (always has an extension),
+    /// not from Photo.FileName (which the indexer stores without extension).
+    /// </summary>
+    [TestMethod]
+    public async Task GetPhotoByIdAsync_FileNameDerivedFromFilePath_IncludesExtension()
+    {
+        // Simulate what the indexer stores: FileName without extension, FilePath with extension.
+        var photo = new Photo
+        {
+            Id = Guid.NewGuid(),
+            FilePath = "/originals/photo.jpg",
+            FileName = "photo",   // extension-less, as stored by RandomizedSidecarIndexer
+            FolderType = FolderType.Originals,
+        };
+        var sibling = new Photo
+        {
+            Id = Guid.NewGuid(),
+            FilePath = "/originals/photo.orf",
+            FileName = "photo",   // extension-less RAW sibling
+            FolderType = FolderType.Originals,
+            DuplicateGroupId = GroupId,
+            IsPreferred = false,
+        };
+        photo = photo with { DuplicateGroupId = GroupId, IsPreferred = true };
+
+        var service = new PhotoService(new StubRepo([photo, sibling]));
+
+        var result = await service.GetPhotoByIdAsync(photo.Id);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("photo.jpg", result.FileName, "Main photo FileName must include extension");
+        var versionFileNames = result.Versions.Select(v => v.FileName).ToList();
+        CollectionAssert.Contains(versionFileNames, "photo.jpg");
+        CollectionAssert.Contains(versionFileNames, "photo.orf");
+    }
+
     [TestMethod]
     public async Task GetPhotoByIdAsync_OnlyOwnGroupSiblings_NotOtherGroups()
     {


### PR DESCRIPTION
## Summary

- **#70 — Full filename in info panel**: The info panel was showing filenames without extension (e.g. `photo` instead of `photo.jpg`) because `Photo.FileName` is stored extension-less by the indexer. Fixed at the DTO mapping layer in `PhotoService` to derive the display name from `FilePath` via `Path.GetFileName`, consistent with how the browse filename filter already works.

- **#71 — Toggle and auto-hide info overlay**: The info overlay (`i`) and index overlay (`x`) previously had no way to dismiss them other than waiting 10 s for the timer. Fixed:
  - Pressing `i` a second time now hides the info panel (toggle)
  - Pressing `x` a second time now hides the index panel (toggle)  
  - The info panel automatically hides when the photo changes (it would otherwise show stale info)
  - The 10 s auto-hide is preserved; the index panel is intentionally not dismissed on photo change (it shows global stats)

  Implemented by extending `useOverlayMessage` with `toggleMessage`/`hideKey`/`hide`, keyed by a stable string per panel type.

## Test plan

- [ ] Backend unit tests: `dotnet test --filter "TestCategory!=Integration"` — new test in `PhotoServiceVersionsTests` covers a photo with extension-less `FileName` and asserts the DTO includes the extension
- [ ] Frontend tests: `pnpm run test` — four new tests in `SlideshowPage.test.tsx` cover toggle-off for `i` and `x`, and hide-on-advance (both manual and auto-advance)
- [ ] Lint + build: `pnpm run lint && pnpm run build`
- [ ] Manual: open slideshow → press `i`, confirm filenames include extension; press `i` again, confirm panel hides; advance photo, confirm panel hides; press `x` twice, confirm toggle

Closes #70
Closes #71