### PR TITLE
fix: wrap crawler per-file DB writes in a single transaction committed after sidecar write

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Reference implementation to draw patterns from: https://github.com/magnusakselvo
   - **Python sub-tool strategy**: Image-heavy steps as standalone Python CLIs under `tools/`, invoked via `Process.Start()` — share sidecar files and SQLite DB, no special IPC (see ADR 001).
   - **Folder discovery**: `ScanRoots` are searched recursively for `_folder.json` files; each such folder becomes an independent crawl unit (`CrawlTargetResolver`). Photos belong to the nearest ancestor unit; photos not under any unit are skipped. Mirrors `FileSystemFolderRepository` on the server side.
   - **Process launch**: crawler is started via `ProcessStartInfo.ArgumentList` (not `Arguments`) so user-supplied fields cannot re-tokenize into extra CLI arguments (see ADR 005).
+  - **Per-file write consistency**: `.meta.json` sidecar is authoritative; `crawled_files`/`step_runs` are a reconcilable cache. Each file's upsert + step-run DB writes share one `SqliteTransaction` (`CrawlFileTransaction`) that commits **only after** the sidecar is written — a crash before the sidecar rolls back the DB atomically; a crash after but before commit re-detects `Changed` and reprocesses idempotently. `step_runs` is advisory/audit only (see ADR 011).
 - **Security — `POST /api/crawler/start`**: requires the `X-Requested-With` header (CSRF guard); `Mode`/`Step` validated against `StartCrawlValidation` (`src/PhotoOrganizer.Application/Crawler/StartCrawlValidation.cs`) — valid modes: `full`, `incremental`, `targeted`; valid steps: `metadata`, `duplicates`. Returns 403 if header absent, 400 if invalid (see ADR 005).
 - **Security — bind address**: server binds loopback-only by default (dev: `localhost:6192` via `launchSettings.json`; published: Kestrel default `localhost:5000`). Do not bind to `0.0.0.0` without auth + rate limiting (see ADR 005).
 
@@ -144,7 +145,7 @@ To regenerate JPEG fixtures: `dotnet run --project tools/PhotoOrganizer.FixtureG
 
 ## Architecture Decision Records (ADRs)
 
-ADRs live in `docs/adr/NNN-kebab-title.md`. The format mirrors `docs/adr/001-crawler-stack.md`: `## Status`, `## Context`, `## Decision`, `## Consequences`. Next available number after this issue: **011**.
+ADRs live in `docs/adr/NNN-kebab-title.md`. The format mirrors `docs/adr/001-crawler-stack.md`: `## Status`, `## Context`, `## Decision`, `## Consequences`. Next available number after this issue: **012**.
 
 **During issue planning**, assess whether the work introduces or reverses an architectural decision — a cross-cutting pattern, a tech/library choice, a security-posture change, a data-contract change, or a consciously-accepted tradeoff (including deliberate deferrals and reversals). If so, propose an ADR as part of the plan.
 

--- a/docs/adr/011-crawler-per-file-write-consistency.md
+++ b/docs/adr/011-crawler-per-file-write-consistency.md
@@ -1,0 +1,96 @@
+# ADR 011: Crawler Per-File Write Consistency — Sidecar Authoritative, DB Reconcilable Cache
+
+## Status
+
+Accepted
+
+## Context
+
+For each new or changed photo file the crawler processes three writes across two independent
+persistence systems:
+
+1. `crawled_files` upsert (SQLite) — records `file_hash` and `modified_at` for change detection.
+2. `step_runs` upsert per pipeline step (SQLite) — records which processing steps completed and at
+   which version.
+3. `.meta.json` sidecar write (filesystem, atomic rename) — records the step completion state used
+   by `PipelineRunner` to decide which steps to skip on the next crawl.
+
+Before this change each write was its own autocommit transaction on its own SQLite connection, and
+they occurred in the order listed above. Two crash scenarios caused silent data loss:
+
+- **Crash between (1) and (3)**: `crawled_files.modified_at` is advanced, so the next incremental
+  crawl's `ChangeDetector` skips the file (mod-time within 1 s → `Unchanged`); the sidecar is
+  never written, so all pipeline steps are silently re-skipped — permanent step loss with no
+  observable error.
+- **Crash between step (2) and the final sidecar write**: individual `step_runs` rows are committed
+  eagerly per step, but the sidecar that `PipelineRunner` reads for skip decisions is only written
+  once at the very end; the DB and sidecar diverge.
+
+The key insight that informed the fix: `step_runs` is **write-only** — no code path reads it back
+to make any decision; all skip logic keys exclusively off the sidecar's `CrawlSteps` dictionary.
+The sidecar is therefore already the de facto authority; the DB just needs to be brought into a
+consistent, recoverable relationship with it.
+
+## Decision
+
+Treat the `.meta.json` sidecar as the authoritative record of step completion. Treat `crawled_files`
+and `step_runs` as a reconcilable cache that must never be advanced past what the sidecar reflects.
+
+**Implementation:** wrap each file's `UpsertAsync` + all `RecordStepRunAsync` calls in a single
+`SqliteTransaction` (`CrawlFileTransaction`) that is committed **only after** the sidecar has been
+durably written to disk.
+
+`CrawlerDatabase.BeginFileTransaction()` opens a connection, applies the WAL/foreign-key PRAGMAs
+(which must precede `BEGIN`), and wraps the result in a `CrawlFileTransaction` — a lightweight
+`IDisposable` holding the connection and transaction. Disposing without calling `Commit()` rolls
+back automatically.
+
+`CrawlOrchestrator.ProcessFileWithPipelineAsync()` is the transaction scope:
+
+```
+using var tx = _db.BeginFileTransaction();
+var dbRecord = await _fileRepo.UpsertAsync(file.FilePath, hash, modifiedAt, tx);
+await _pipeline.RunAsync(file.FilePath, dbRecord, tx);   // writes sidecar last
+tx.Commit();                                              // DB durable only after sidecar
+```
+
+`PipelineRunner.RunAsync` writes the sidecar as its final step (unchanged), then returns — the
+commit in the orchestrator follows immediately after. `RecordStepRunAsync` calls inside the pipeline
+pass the same transaction and accumulate their writes within it; none of them are visible outside
+the transaction until commit.
+
+### Crash analysis
+
+| Crash moment | Sidecar state | DB state | Next crawl behaviour |
+|---|---|---|---|
+| Before sidecar write | Untouched (old) | Tx rolled back → old | Reprocesses correctly |
+| After sidecar write, before commit | New (durable) | Tx rolled back → old hash/modtime | `Changed` detected → reprocesses → step-skip skips already-done steps (idempotent) |
+| After commit | New (durable) | New (committed) | `Unchanged` → skipped correctly |
+
+All crash states are consistent and recoverable — there is no window for silent step loss.
+
+### Out of scope
+
+`RunTargetedAsync` (batch-step-only upsert) and `ModTimeOnly` (timestamp-only update) are left as
+autocommit; they do not touch the sidecar in the same coupled way. The failed-step retry gap (a
+failed step still advances `file_hash`, so it is not retried on the next incremental crawl) is
+pre-existing behaviour and is left for a future issue.
+
+## Consequences
+
+**Positive:**
+- Crash during per-file processing can no longer silently lose step results.
+- All three writes (`crawled_files`, `step_runs`, sidecar) are committed atomically from the
+  observer's perspective, with the sidecar as the commit point.
+- The fix is additive: `UpsertAsync` and `RecordStepRunAsync` accept an optional
+  `CrawlFileTransaction? tx = null` parameter; existing callers without a transaction continue to
+  work in autocommit mode.
+
+**Accepted tradeoffs:**
+- A write lock on the SQLite WAL file is held for the duration of one file's pipeline execution
+  (metadata extraction, etc.). The crawler is single-writer by design; there is no concurrent writer
+  to contend with, so the lock is never contested.
+- Batch processing steps (duplicate detection via Python sub-tools) run outside this transaction
+  scope — they write sidecars independently and do not need the same crash guarantee.
+- `step_runs` remains advisory/audit-only. It accurately reflects the committed state after this
+  change, but nothing reads it for operational decisions.

--- a/src/PhotoOrganizer.Crawler/CrawlOrchestrator.cs
+++ b/src/PhotoOrganizer.Crawler/CrawlOrchestrator.cs
@@ -16,6 +16,7 @@ public sealed class CrawlOrchestrator
     private readonly ChangeDetector _changeDetector;
     private readonly PipelineRunner _pipeline;
     private readonly IReadOnlyList<IBatchProcessingStep> _batchSteps;
+    private readonly CrawlerDatabase _db;
 
     public CrawlOrchestrator(
         ICrawledFileRepository fileRepo,
@@ -24,6 +25,7 @@ public sealed class CrawlOrchestrator
         ICrawlTargetResolver resolver,
         ChangeDetector changeDetector,
         PipelineRunner pipeline,
+        CrawlerDatabase db,
         IReadOnlyList<IBatchProcessingStep>? batchSteps = null)
     {
         _fileRepo = fileRepo;
@@ -32,6 +34,7 @@ public sealed class CrawlOrchestrator
         _resolver = resolver;
         _changeDetector = changeDetector;
         _pipeline = pipeline;
+        _db = db;
         _batchSteps = batchSteps ?? [];
     }
 
@@ -67,8 +70,7 @@ public sealed class CrawlOrchestrator
                     {
                         if (fullMode)
                         {
-                            var dbRecord = await _fileRepo.UpsertAsync(file.FilePath, null, file.LastModified);
-                            await _pipeline.RunAsync(file.FilePath, dbRecord);
+                            await ProcessFileWithPipelineAsync(file, null);
                             filesProcessed++;
                         }
                         else
@@ -90,8 +92,7 @@ public sealed class CrawlOrchestrator
 
                                 case ChangeKind.New:
                                 case ChangeKind.Changed:
-                                    var dbRecord = await _fileRepo.UpsertAsync(file.FilePath, change.ComputedHash, file.LastModified);
-                                    await _pipeline.RunAsync(file.FilePath, dbRecord);
+                                    await ProcessFileWithPipelineAsync(file, change.ComputedHash);
                                     filesProcessed++;
                                     break;
                             }
@@ -144,6 +145,21 @@ public sealed class CrawlOrchestrator
             await _logRepo.CompleteCrawlAsync(crawlId, "failed", filesScanned, filesProcessed, filesErrored, ex.Message);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Upserts the file record, runs the processing pipeline (which writes the sidecar at the
+    /// very end of <see cref="PipelineRunner.RunAsync"/>), then commits the DB transaction — so
+    /// the DB is only advanced once the sidecar is durably on disk.  A crash before the sidecar
+    /// write rolls the transaction back automatically on dispose, leaving both stores in their
+    /// prior consistent state.
+    /// </summary>
+    private async Task ProcessFileWithPipelineAsync(DiscoveredFile file, string? computedHash)
+    {
+        using var tx = _db.BeginFileTransaction();
+        var dbRecord = await _fileRepo.UpsertAsync(file.FilePath, computedHash, file.LastModified, tx);
+        await _pipeline.RunAsync(file.FilePath, dbRecord, tx);
+        tx.Commit();
     }
 
     public async Task RunTargetedAsync(IReadOnlyList<string> folderPaths, string stepName)

--- a/src/PhotoOrganizer.Crawler/CrawlerServices.cs
+++ b/src/PhotoOrganizer.Crawler/CrawlerServices.cs
@@ -33,7 +33,7 @@ public sealed class CrawlerServices : IDisposable
         var pipeline = new PipelineRunner(registry, sidecarStore, fileRepo);
         var resolver = new CrawlTargetResolver(sidecarStore, discoverer);
 
-        var orchestrator = new CrawlOrchestrator(fileRepo, logRepo, sidecarStore, resolver, changeDetector, pipeline, registry.BatchSteps);
+        var orchestrator = new CrawlOrchestrator(fileRepo, logRepo, sidecarStore, resolver, changeDetector, pipeline, db, registry.BatchSteps);
         return new CrawlerServices(orchestrator);
     }
 

--- a/src/PhotoOrganizer.Crawler/Data/CrawlFileTransaction.cs
+++ b/src/PhotoOrganizer.Crawler/Data/CrawlFileTransaction.cs
@@ -1,0 +1,27 @@
+using Microsoft.Data.Sqlite;
+
+namespace PhotoOrganizer.Crawler.Data;
+
+/// <summary>
+/// Holds a SQLite connection and an open transaction scoped to one file's DB writes.
+/// Dispose rolls back if <see cref="Commit"/> was never called.
+/// </summary>
+public sealed class CrawlFileTransaction : IDisposable
+{
+    internal SqliteConnection Connection { get; }
+    internal SqliteTransaction Transaction { get; }
+
+    internal CrawlFileTransaction(SqliteConnection connection, SqliteTransaction transaction)
+    {
+        Connection = connection;
+        Transaction = transaction;
+    }
+
+    public void Commit() => Transaction.Commit();
+
+    public void Dispose()
+    {
+        Transaction.Dispose();
+        Connection.Dispose();
+    }
+}

--- a/src/PhotoOrganizer.Crawler/Data/CrawlerDatabase.cs
+++ b/src/PhotoOrganizer.Crawler/Data/CrawlerDatabase.cs
@@ -68,6 +68,17 @@ public sealed class CrawlerDatabase
         return connection;
     }
 
+    /// <summary>
+    /// Opens a connection and begins a transaction for one file's DB writes.
+    /// Disposing the returned handle without calling <see cref="CrawlFileTransaction.Commit"/>
+    /// rolls back automatically.
+    /// </summary>
+    public CrawlFileTransaction BeginFileTransaction()
+    {
+        var connection = OpenConnection();
+        return new CrawlFileTransaction(connection, connection.BeginTransaction());
+    }
+
     public void Initialize()
     {
         using var connection = OpenConnection();

--- a/src/PhotoOrganizer.Crawler/Data/ICrawledFileRepository.cs
+++ b/src/PhotoOrganizer.Crawler/Data/ICrawledFileRepository.cs
@@ -3,9 +3,9 @@ namespace PhotoOrganizer.Crawler.Data;
 public interface ICrawledFileRepository
 {
     Task<CrawledFileRecord?> GetByPathAsync(string filePath);
-    Task<CrawledFileRecord> UpsertAsync(string filePath, string? fileHash, DateTimeOffset modifiedAt);
+    Task<CrawledFileRecord> UpsertAsync(string filePath, string? fileHash, DateTimeOffset modifiedAt, CrawlFileTransaction? tx = null);
     Task MarkDeletedAsync(IEnumerable<int> fileIds);
     Task UpdateModifiedAtAsync(int fileId, DateTimeOffset modifiedAt);
     Task<IReadOnlyList<CrawledFileRecord>> GetActiveFilesAsync();
-    Task RecordStepRunAsync(int fileId, string stepName, int stepVersion, string status, string? errorMessage);
+    Task RecordStepRunAsync(int fileId, string stepName, int stepVersion, string status, string? errorMessage, CrawlFileTransaction? tx = null);
 }

--- a/src/PhotoOrganizer.Crawler/Data/SqliteCrawledFileRepository.cs
+++ b/src/PhotoOrganizer.Crawler/Data/SqliteCrawledFileRepository.cs
@@ -23,27 +23,35 @@ public sealed class SqliteCrawledFileRepository : ICrawledFileRepository
         return ReadRecord(reader);
     }
 
-    public async Task<CrawledFileRecord> UpsertAsync(string filePath, string? fileHash, DateTimeOffset modifiedAt)
+    public async Task<CrawledFileRecord> UpsertAsync(string filePath, string? fileHash, DateTimeOffset modifiedAt, CrawlFileTransaction? tx = null)
     {
-        using var connection = _db.OpenConnection();
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = """
-            INSERT INTO crawled_files (file_path, file_hash, modified_at, last_crawled_at, deleted)
-            VALUES (@path, @hash, @modifiedAt, @now, 0)
-            ON CONFLICT(file_path) DO UPDATE SET
-                file_hash = excluded.file_hash,
-                modified_at = excluded.modified_at,
-                last_crawled_at = excluded.last_crawled_at,
-                deleted = 0
-            RETURNING id, file_path, file_hash, modified_at, first_seen_at, last_crawled_at, deleted
-            """;
-        cmd.Parameters.AddWithValue("@path", filePath);
-        cmd.Parameters.AddWithValue("@hash", (object?)fileHash ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("@modifiedAt", modifiedAt.ToString("O"));
-        cmd.Parameters.AddWithValue("@now", DateTimeOffset.UtcNow.ToString("O"));
-        using var reader = await cmd.ExecuteReaderAsync();
-        await reader.ReadAsync();
-        return ReadRecord(reader);
+        var connection = tx?.Connection ?? _db.OpenConnection();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            if (tx is not null) cmd.Transaction = tx.Transaction;
+            cmd.CommandText = """
+                INSERT INTO crawled_files (file_path, file_hash, modified_at, last_crawled_at, deleted)
+                VALUES (@path, @hash, @modifiedAt, @now, 0)
+                ON CONFLICT(file_path) DO UPDATE SET
+                    file_hash = excluded.file_hash,
+                    modified_at = excluded.modified_at,
+                    last_crawled_at = excluded.last_crawled_at,
+                    deleted = 0
+                RETURNING id, file_path, file_hash, modified_at, first_seen_at, last_crawled_at, deleted
+                """;
+            cmd.Parameters.AddWithValue("@path", filePath);
+            cmd.Parameters.AddWithValue("@hash", (object?)fileHash ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@modifiedAt", modifiedAt.ToString("O"));
+            cmd.Parameters.AddWithValue("@now", DateTimeOffset.UtcNow.ToString("O"));
+            using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+            return ReadRecord(reader);
+        }
+        finally
+        {
+            if (tx is null) connection.Dispose();
+        }
     }
 
     public async Task MarkDeletedAsync(IEnumerable<int> fileIds)
@@ -83,26 +91,34 @@ public sealed class SqliteCrawledFileRepository : ICrawledFileRepository
         return results;
     }
 
-    public async Task RecordStepRunAsync(int fileId, string stepName, int stepVersion, string status, string? errorMessage)
+    public async Task RecordStepRunAsync(int fileId, string stepName, int stepVersion, string status, string? errorMessage, CrawlFileTransaction? tx = null)
     {
-        using var connection = _db.OpenConnection();
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = """
-            INSERT INTO step_runs (file_id, step_name, step_version, completed_at, status, error_message)
-            VALUES (@fileId, @stepName, @stepVersion, @now, @status, @errorMessage)
-            ON CONFLICT(file_id, step_name) DO UPDATE SET
-                step_version = excluded.step_version,
-                completed_at = excluded.completed_at,
-                status = excluded.status,
-                error_message = excluded.error_message
-            """;
-        cmd.Parameters.AddWithValue("@fileId", fileId);
-        cmd.Parameters.AddWithValue("@stepName", stepName);
-        cmd.Parameters.AddWithValue("@stepVersion", stepVersion);
-        cmd.Parameters.AddWithValue("@now", DateTimeOffset.UtcNow.ToString("O"));
-        cmd.Parameters.AddWithValue("@status", status);
-        cmd.Parameters.AddWithValue("@errorMessage", (object?)errorMessage ?? DBNull.Value);
-        await cmd.ExecuteNonQueryAsync();
+        var connection = tx?.Connection ?? _db.OpenConnection();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            if (tx is not null) cmd.Transaction = tx.Transaction;
+            cmd.CommandText = """
+                INSERT INTO step_runs (file_id, step_name, step_version, completed_at, status, error_message)
+                VALUES (@fileId, @stepName, @stepVersion, @now, @status, @errorMessage)
+                ON CONFLICT(file_id, step_name) DO UPDATE SET
+                    step_version = excluded.step_version,
+                    completed_at = excluded.completed_at,
+                    status = excluded.status,
+                    error_message = excluded.error_message
+                """;
+            cmd.Parameters.AddWithValue("@fileId", fileId);
+            cmd.Parameters.AddWithValue("@stepName", stepName);
+            cmd.Parameters.AddWithValue("@stepVersion", stepVersion);
+            cmd.Parameters.AddWithValue("@now", DateTimeOffset.UtcNow.ToString("O"));
+            cmd.Parameters.AddWithValue("@status", status);
+            cmd.Parameters.AddWithValue("@errorMessage", (object?)errorMessage ?? DBNull.Value);
+            await cmd.ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            if (tx is null) connection.Dispose();
+        }
     }
 
     private static CrawledFileRecord ReadRecord(SqliteDataReader reader) => new()

--- a/src/PhotoOrganizer.Crawler/Pipeline/PipelineRunner.cs
+++ b/src/PhotoOrganizer.Crawler/Pipeline/PipelineRunner.cs
@@ -18,7 +18,7 @@ public sealed class PipelineRunner
         _fileRepo = fileRepo;
     }
 
-    public async Task RunAsync(string filePath, CrawledFileRecord dbRecord)
+    public async Task RunAsync(string filePath, CrawledFileRecord dbRecord, CrawlFileTransaction? tx = null)
     {
         var sidecar = await _sidecarStore.ReadPhotoMetaAsync(filePath)
             ?? new PhotoMetaSidecar();
@@ -51,7 +51,7 @@ public sealed class PipelineRunner
                     CompletedAt = DateTimeOffset.UtcNow
                 };
 
-                await _fileRepo.RecordStepRunAsync(dbRecord.Id, step.Name, step.Version, "completed", null);
+                await _fileRepo.RecordStepRunAsync(dbRecord.Id, step.Name, step.Version, "completed", null, tx);
                 anyStepRan = true;
 
                 Log.Debug("Completed step {StepName} for {FilePath}", step.Name, filePath);
@@ -59,7 +59,7 @@ public sealed class PipelineRunner
             catch (Exception ex)
             {
                 Log.Warning(ex, "Step {StepName} failed for {FilePath}", step.Name, filePath);
-                await _fileRepo.RecordStepRunAsync(dbRecord.Id, step.Name, step.Version, "failed", ex.Message);
+                await _fileRepo.RecordStepRunAsync(dbRecord.Id, step.Name, step.Version, "failed", ex.Message, tx);
                 // Stop processing remaining steps for this file since later steps may depend on this one
                 break;
             }

--- a/tests/PhotoOrganizer.Crawler.Tests/CrawlFileTransactionTests.cs
+++ b/tests/PhotoOrganizer.Crawler.Tests/CrawlFileTransactionTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.Data.Sqlite;
+using PhotoOrganizer.Crawler.Data;
+
+namespace PhotoOrganizer.Crawler.Tests;
+
+/// <summary>
+/// Integration tests verifying that <see cref="CrawlerDatabase.BeginFileTransaction"/> produces
+/// a real SQLite transaction that rolls back on dispose and commits when explicitly committed.
+/// These tests use a real on-disk temp SQLite database.
+/// </summary>
+[TestClass]
+[TestCategory("Integration")]
+public class CrawlFileTransactionTests
+{
+    private static string _dbPath = null!;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext _)
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"crawler-tx-test-{Guid.NewGuid():N}.db");
+        var db = new CrawlerDatabase(_dbPath);
+        db.Initialize();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath))
+            File.Delete(_dbPath);
+    }
+
+    [TestMethod]
+    public async Task UpsertAsync_WithTransactionRolledBack_LeavesNoPersistentRow()
+    {
+        var db = new CrawlerDatabase(_dbPath);
+        var repo = new SqliteCrawledFileRepository(db);
+
+        const string filePath = "/test/rollback.jpg";
+
+        // Insert an initial row so we can verify it's untouched after rollback
+        var original = await repo.UpsertAsync(filePath, "original-hash", DateTimeOffset.UtcNow);
+
+        // Begin a transaction, update the row within it, then dispose WITHOUT committing
+        using (var tx = db.BeginFileTransaction())
+        {
+            await repo.UpsertAsync(filePath, "new-hash", DateTimeOffset.UtcNow, tx);
+            // tx.Commit() deliberately omitted — dispose rolls back
+        }
+
+        // The row should still have the original hash
+        var after = await repo.GetByPathAsync(filePath);
+        Assert.IsNotNull(after);
+        Assert.AreEqual("original-hash", after.FileHash, "Rolled-back transaction must not persist the new hash");
+    }
+
+    [TestMethod]
+    public async Task UpsertAsync_WithTransactionCommitted_PersistsRow()
+    {
+        var db = new CrawlerDatabase(_dbPath);
+        var repo = new SqliteCrawledFileRepository(db);
+
+        const string filePath = "/test/commit.jpg";
+
+        using (var tx = db.BeginFileTransaction())
+        {
+            await repo.UpsertAsync(filePath, "committed-hash", DateTimeOffset.UtcNow, tx);
+            tx.Commit();
+        }
+
+        var after = await repo.GetByPathAsync(filePath);
+        Assert.IsNotNull(after);
+        Assert.AreEqual("committed-hash", after.FileHash, "Committed transaction must persist the hash");
+    }
+
+    [TestMethod]
+    public async Task RecordStepRunAsync_WithTransactionRolledBack_LeavesNoStepRunRow()
+    {
+        var db = new CrawlerDatabase(_dbPath);
+        var repo = new SqliteCrawledFileRepository(db);
+
+        // Create the file row first (autocommit, so it survives any later rollback)
+        const string filePath = "/test/step-rollback.jpg";
+        var record = await repo.UpsertAsync(filePath, "hash-sr", DateTimeOffset.UtcNow);
+
+        // Begin a transaction, write a step_runs row, then dispose WITHOUT committing
+        using (var tx = db.BeginFileTransaction())
+        {
+            await repo.RecordStepRunAsync(record.Id, "metadata", 1, "completed", null, tx);
+            // tx.Commit() deliberately omitted
+        }
+
+        // Verify the step_runs row was not written
+        using var connection = db.OpenConnection();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM step_runs WHERE file_id = @id AND step_name = 'metadata'";
+        cmd.Parameters.AddWithValue("@id", record.Id);
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0L);
+        Assert.AreEqual(0L, count, "Rolled-back transaction must not persist the step_runs row");
+    }
+
+    [TestMethod]
+    public async Task RecordStepRunAsync_WithTransactionCommitted_PersistsStepRunRow()
+    {
+        var db = new CrawlerDatabase(_dbPath);
+        var repo = new SqliteCrawledFileRepository(db);
+
+        const string filePath = "/test/step-commit.jpg";
+        var record = await repo.UpsertAsync(filePath, "hash-sc", DateTimeOffset.UtcNow);
+
+        using (var tx = db.BeginFileTransaction())
+        {
+            await repo.RecordStepRunAsync(record.Id, "metadata", 1, "completed", null, tx);
+            tx.Commit();
+        }
+
+        using var connection = db.OpenConnection();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM step_runs WHERE file_id = @id AND step_name = 'metadata'";
+        cmd.Parameters.AddWithValue("@id", record.Id);
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0L);
+        Assert.AreEqual(1L, count, "Committed transaction must persist the step_runs row");
+    }
+
+    [TestMethod]
+    public async Task UpsertAndRecordStepRun_WithinSameTransaction_BothRollBackTogether()
+    {
+        var db = new CrawlerDatabase(_dbPath);
+        var repo = new SqliteCrawledFileRepository(db);
+
+        const string filePath = "/test/combined-rollback.jpg";
+
+        // Put a baseline row in
+        var original = await repo.UpsertAsync(filePath, "base-hash", DateTimeOffset.UtcNow);
+
+        // Now update both crawled_files and step_runs within one tx, then roll back
+        using (var tx = db.BeginFileTransaction())
+        {
+            var updated = await repo.UpsertAsync(filePath, "tx-hash", DateTimeOffset.UtcNow, tx);
+            await repo.RecordStepRunAsync(updated.Id, "metadata", 1, "completed", null, tx);
+            // No Commit — rollback on dispose
+        }
+
+        // crawled_files hash unchanged
+        var afterFile = await repo.GetByPathAsync(filePath);
+        Assert.AreEqual("base-hash", afterFile?.FileHash, "File hash must be rolled back");
+
+        // step_runs row absent
+        using var connection = db.OpenConnection();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM step_runs WHERE file_id = @id";
+        cmd.Parameters.AddWithValue("@id", original.Id);
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0L);
+        Assert.AreEqual(0L, count, "step_runs row must be rolled back together with the file row");
+    }
+}

--- a/tests/PhotoOrganizer.Crawler.Tests/PhotoOrganizer.Crawler.Tests.csproj
+++ b/tests/PhotoOrganizer.Crawler.Tests/PhotoOrganizer.Crawler.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="MSTest" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />

--- a/tests/PhotoOrganizer.Crawler.Tests/PipelineRunnerTests.cs
+++ b/tests/PhotoOrganizer.Crawler.Tests/PipelineRunnerTests.cs
@@ -149,14 +149,14 @@ public class PipelineRunnerTests
         public List<(string StepName, string Status)> StepRuns { get; } = [];
 
         public Task<CrawledFileRecord?> GetByPathAsync(string filePath) => Task.FromResult<CrawledFileRecord?>(null);
-        public Task<CrawledFileRecord> UpsertAsync(string filePath, string? fileHash, DateTimeOffset modifiedAt) =>
+        public Task<CrawledFileRecord> UpsertAsync(string filePath, string? fileHash, DateTimeOffset modifiedAt, CrawlFileTransaction? tx = null) =>
             Task.FromResult(new CrawledFileRecord { Id = 1, FilePath = filePath, FirstSeenAt = DateTimeOffset.UtcNow });
         public Task MarkDeletedAsync(IEnumerable<int> fileIds) => Task.CompletedTask;
         public Task UpdateModifiedAtAsync(int fileId, DateTimeOffset modifiedAt) => Task.CompletedTask;
         public Task<IReadOnlyList<CrawledFileRecord>> GetActiveFilesAsync() =>
             Task.FromResult<IReadOnlyList<CrawledFileRecord>>([]);
 
-        public Task RecordStepRunAsync(int fileId, string stepName, int stepVersion, string status, string? errorMessage)
+        public Task RecordStepRunAsync(int fileId, string stepName, int stepVersion, string status, string? errorMessage, CrawlFileTransaction? tx = null)
         {
             StepRuns.Add((stepName, status));
             return Task.CompletedTask;


### PR DESCRIPTION
## Summary

- Introduces `CrawlFileTransaction` — a lightweight `IDisposable` holding a `SqliteConnection` + `SqliteTransaction` scoped to one file's pipeline run
- `CrawlerDatabase.BeginFileTransaction()` opens the connection, applies WAL/FK pragmas, and returns the handle
- `CrawlOrchestrator.ProcessFileWithPipelineAsync()` is the transaction scope: upsert → pipeline (which writes the sidecar last) → commit; a crash before the sidecar rolls the DB back automatically on dispose
- `UpsertAsync` and `RecordStepRunAsync` accept an optional `CrawlFileTransaction? tx = null`; callers without a tx continue to work in autocommit mode
- Adds 4 integration tests (`CrawlFileTransactionTests`) verifying rollback and commit semantics against a real temp SQLite DB
- Adds ADR 011 documenting the sidecar-authoritative / DB-reconcilable-cache contract

## Problem

Before this change, per-file processing wrote to three places with no spanning transaction:

1. `crawled_files` upsert (autocommit) — advances `modified_at` / `file_hash`
2. `step_runs` upsert per step (autocommit) — written eagerly after each step
3. `.meta.json` sidecar write (atomic rename) — written once at the very end

A crash between step 1 and step 3 left `crawled_files.modified_at` advanced, so the next incremental crawl's `ChangeDetector` saw the file as `Unchanged` and skipped it — while the sidecar was never written, causing **silent permanent step loss** with no observable error.

## Crash recovery after the fix

| Crash moment | Sidecar | DB | Next crawl |
|---|---|---|---|
| Before sidecar write | old | tx rolled back → old | Reprocesses correctly |
| After sidecar write, before commit | new (durable) | tx rolled back → old hash | `Changed` detected → reprocesses → step-skip skips already-done steps |
| After commit | new | new | `Unchanged` → skipped correctly |

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test --filter "TestCategory!=Integration"` — 261 unit tests pass
- [x] `dotnet test --filter "TestCategory=Integration"` — 24 integration tests pass (incl. 4 new `CrawlFileTransactionTests` + existing `EndToEndTests` / `HeicTranscodingTests`)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)