### PR TITLE
docs: clarify that merging is done by the user, not Claude

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,9 @@ Always use GitHub Flow when working on issues:
 
 4. **Wait for CI and fix failures**: after opening the PR, poll `gh pr checks <number>` until all checks complete. If any job fails, read the full log (`gh run view <run-id> --job <job-id> --log`), fix the root cause, commit, and push. Repeat until CI is green. Do not hand back to the user with a failing CI.
 
-5. **Merge** after review (squash merge preferred for clean history)
+5. **Merge**: done by the user outside the agentic session — never merge a PR yourself.
 
-5. **Clean up** after the user confirms a PR is merged:
+6. **Clean up** after the user confirms a PR is merged:
    - `git fetch origin && git checkout main && git pull`
    - `git branch -d <branch-name>`
 


### PR DESCRIPTION
Fixes a leftover from PR #98: step 5 still said "Merge after review (squash merge preferred for clean history)" and there were two steps numbered 5. This corrects both.

- Step 5: "Merge: done by the user outside the agentic session — never merge a PR yourself."
- Step 6 (was duplicate 5): "Clean up after the user confirms a PR is merged"

🤖 Generated with [Claude Code](https://claude.com/claude-code)